### PR TITLE
Fix "argument list too long" error.

### DIFF
--- a/client.go
+++ b/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"sync"
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
@@ -23,15 +24,22 @@ const (
 	Version = "0.1"
 )
 
+var appendPathOnce sync.Once
+
 // New nri client
 func New() (*Client, error) {
 	conf, err := loadConfig(DefaultConfPath)
 	if err != nil {
 		return nil, err
 	}
-	if err := os.Setenv("PATH", fmt.Sprintf("%s:%s", os.Getenv("PATH"), DefaultBinaryPath)); err != nil {
+
+	appendPathOnce.Do(func() {
+		err = os.Setenv("PATH", fmt.Sprintf("%s:%s", os.Getenv("PATH"), DefaultBinaryPath))
+	})
+	if err != nil {
 		return nil, err
 	}
+
 	return &Client{
 		conf: conf,
 	}, nil


### PR DESCRIPTION
When running from a service, each `client.New` call will [append one more entry](https://github.com/containerd/nri/blob/5e52908d1c3c2b4c67e92a8781010257695c065e/client.go#L32) to PATH.
Indirectly this affects fork/exec calls (the error message is a bit misleading, ideally
it should be something like "argument list and environment are too long").

The problem can be reproduced with the following test:

```
func TestNewClient(t *testing.T) {
	for i := 0; i < 11000; i++ {
		_, err := New();
		if err != nil {
			t.Fatal(err)
		}

		_, err = exec.Command("true").CombinedOutput()
		if err != nil {
			t.Fatal(err)
		}
	}
}

--- FAIL: TestNewClient (7.84s)
    client_test.go:17: fork/exec /usr/bin/true: argument list too long
FAIL
exit status 1
```

In cri-containerd I observed this error after launching ~50 pods

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>