### PR TITLE
Merge PluginError into Result

### DIFF
--- a/types/v1/types.go
+++ b/types/v1/types.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"encoding/json"
-	"fmt"
+	"github.com/pkg/errors"
 )
 
 // Plugin type and configuration
@@ -81,27 +81,6 @@ type Request struct {
 	Results []*Result `json:"results,omitempty"`
 }
 
-// NewPluginError returns a plugin error
-func NewPluginError(name string, err error) error {
-	return &PluginError{
-		Plugin:  name,
-		Message: err.Error(),
-	}
-}
-
-// PluginError for specific plugin execution
-type PluginError struct {
-	// Plugin name
-	Plugin string `json:"plugin"`
-	// Message for the error
-	Message string `json:"message"`
-}
-
-// Error as a string
-func (p *PluginError) Error() string {
-	return fmt.Sprintf("%s: %s", p.Plugin, p.Message)
-}
-
 // IsSandbox returns true if the request is for a sandbox
 func (r *Request) IsSandbox() bool {
 	return r.ID == r.SandboxID
@@ -122,6 +101,16 @@ type Result struct {
 	Plugin string `json:"plugin"`
 	// Version of the plugin
 	Version string `json:"version"`
+	// Error message in case of failures
+	Error string `json:"error"`
 	// Metadata specific to actions taken by the plugin
 	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+// Err creates an Error object if ErrorMessage is populated
+func (r *Result) Err() error {
+	if r.Error != "" {
+		return errors.New(r.Error)
+	}
+	return nil
 }


### PR DESCRIPTION
Merge the PluginError struct into Result. This allows the NRI skeleton and invocation to encode and un-marshal to a single type and cleans up the code a bit.

Error messages from injected errors:
```
nri invoke: plugin: testplugin: injected structured error
```
```
nri invoke: plugin: testplugin: failed to unmarshal plugin output: unexpected end of JSON input: output: <empty> exit code: 1
```
```
nri invoke: plugin: testplugin: failed to unmarshal plugin output: invalid character 'i' looking for beginning of value: output: "injected invalid output"
```
```
nri invoke: plugin: testplugin: exec: "missing": executable file not found in $PATH
```
Signed-off-by: Deep Debroy <ddebroy@apple.com>