### PR TITLE
README: fix JSON syntax-error, and reformat JSON examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,18 +38,18 @@ The config's default location will be `/etc/nri/resource.d/*.conf`.
 
 ```json
 {
-        "version": "0.1",
-        "plugins": [
-                {
-                        "type": "konfine",
-                        "conf": {
-                                "systemReserved": [0,1]
-                        }
-                },
-                {
-                        "type": "clearcfs"
-                }
-        ]
+  "version": "0.1",
+  "plugins": [
+    {
+      "type": "konfine",
+      "conf": {
+        "systemReserved": [0, 1]
+      }
+    },
+    {
+      "type": "clearcfs"
+    }
+  ]
 }
 ```
 
@@ -59,23 +59,22 @@ Input to a plugin is provided via `STDIN` as a `json` payload.
 
 ```json
 {
-	"version": "0.1",
-	"state": "create",
-	"id": "redis",
-	"pid": 1234,
-	"spec": {
-		"resources": {
-		},
-		"cgroupsPath": "default/redis",
-		"namespaces": {
-			"pid": "/proc/44/ns/pid",
-			"mount": "/proc/44/ns/mnt",
-			"net": "/proc/44/ns/net",
-		},
-		"annotations": {
-			"qos.class: "ls"
-		}
-	}
+  "version": "0.1",
+  "state": "create",
+  "id": "redis",
+  "pid": 1234,
+  "spec": {
+    "resources": {},
+    "cgroupsPath": "default/redis",
+    "namespaces": {
+      "pid": "/proc/44/ns/pid",
+      "mount": "/proc/44/ns/mnt",
+      "net": "/proc/44/ns/net"
+    },
+    "annotations": {
+      "qos.class": "ls"
+    }
+  }
 }
 ```
 
@@ -83,11 +82,11 @@ Input to a plugin is provided via `STDIN` as a `json` payload.
 
 ```json
 {
-	"version": "0.1",
-	"state": "create",
-	"id": "redis",
-	"pid": 1234,
-    "cgroupsPath": "qos-ls/default/redis"
+  "version": "0.1",
+  "state": "create",
+  "id": "redis",
+  "pid": 1234,
+  "cgroupsPath": "qos-ls/default/redis"
 }
 ```
 


### PR DESCRIPTION
Use 2 spaces for indentation instead of mixed tabs/spaces, which didn't render nicely on GitHub
