### PR TITLE
stub: fix a potential plugin crash.

### DIFF
--- a/pkg/adaptation/adaptation_suite_test.go
+++ b/pkg/adaptation/adaptation_suite_test.go
@@ -1285,13 +1285,35 @@ var _ = Describe("Unsolicited container update requests", func() {
 		s.Cleanup()
 	})
 
-	When("when there are plugins", func() {
+	When("there are plugins", func() {
 		BeforeEach(func() {
 			var (
 				config = ""
 			)
 
 			s.Prepare(config, &mockRuntime{}, &mockPlugin{idx: "00", name: "test"})
+		})
+
+		It("should fail gracefully without unstarted plugins", func() {
+			var (
+				plugin = s.plugins[0]
+			)
+
+			s.StartRuntime()
+			Expect(plugin.Init(s.Dir())).To(Succeed())
+
+			updates := []*api.ContainerUpdate{
+				{
+					ContainerId: "pod0",
+					Linux: &api.LinuxContainerUpdate{
+						Resources: &api.LinuxResources{
+							RdtClass: api.String("test"),
+						},
+					},
+				},
+			}
+			_, err := plugin.stub.UpdateContainers(updates)
+			Expect(err).ToNot(BeNil())
 		})
 
 		It("should be delivered, without crash/panic", func() {

--- a/pkg/stub/stub.go
+++ b/pkg/stub/stub.go
@@ -18,6 +18,7 @@ package stub
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	stdnet "net"
 	"os"
@@ -160,6 +161,10 @@ var (
 
 	// Used instead of a nil Context in logging.
 	noCtx = context.TODO()
+
+	// ErrNoService indicates that the stub has no runtime service/connection,
+	// for instance by UpdateContainers on a stub which has not been started.
+	ErrNoService = errors.New("stub: no service/connection")
 )
 
 // EventMask holds a mask of events for plugin subscription.
@@ -515,6 +520,10 @@ func (stub *stub) connClosed() {
 
 // UpdateContainers requests unsolicited updates to containers.
 func (stub *stub) UpdateContainers(update []*api.ContainerUpdate) ([]*api.ContainerUpdate, error) {
+	if stub.runtime == nil {
+		return nil, ErrNoService
+	}
+
 	ctx := context.Background()
 	req := &api.UpdateContainersRequest{
 		Update: update,


### PR DESCRIPTION
Don't crash a plugin if it tries to use `stub.UpdateContainers()` without `Start()`ing the stub first. It has no/a nil runtime service at that point.
