### PR TITLE
Make plugin timeouts configurable, adjust default socket path.

### DIFF
--- a/pkg/adaptation/adaptation.go
+++ b/pkg/adaptation/adaptation.go
@@ -373,7 +373,7 @@ func (r *Adaptation) startListener() error {
 	}
 
 	os.Remove(r.socketPath)
-	if err := os.MkdirAll(filepath.Dir(r.socketPath), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(r.socketPath), 0700); err != nil {
 		return fmt.Errorf("failed to create socket %q: %w", r.socketPath, err)
 	}
 

--- a/pkg/adaptation/plugin.go
+++ b/pkg/adaptation/plugin.go
@@ -36,8 +36,16 @@ import (
 )
 
 const (
-	pluginRegistrationTimeout = 2 * time.Second
-	pluginRequestTimeout      = 2 * time.Second
+	// DefaultPluginRegistrationTimeout is the default timeout for plugin registration.
+	DefaultPluginRegistrationTimeout = 5 * time.Second
+	// DefaultPluginRequestTimeout is the default timeout for plugins to handle a request.
+	DefaultPluginRequestTimeout = 2 * time.Second
+)
+
+var (
+	pluginRegistrationTimeout = DefaultPluginRegistrationTimeout
+	pluginRequestTimeout      = DefaultPluginRequestTimeout
+	timeoutCfgLock            sync.RWMutex
 )
 
 type plugin struct {
@@ -57,6 +65,32 @@ type plugin struct {
 	regC   chan error
 	closeC chan struct{}
 	r      *Adaptation
+}
+
+// SetPluginRegistrationTimeout sets the timeout for plugin registration.
+func SetPluginRegistrationTimeout(t time.Duration) {
+	timeoutCfgLock.Lock()
+	defer timeoutCfgLock.Unlock()
+	pluginRegistrationTimeout = t
+}
+
+func getPluginRegistrationTimeout() time.Duration {
+	timeoutCfgLock.RLock()
+	defer timeoutCfgLock.RUnlock()
+	return pluginRegistrationTimeout
+}
+
+// SetPluginRequestTimeout sets the timeout for plugins to handle a request.
+func SetPluginRequestTimeout(t time.Duration) {
+	timeoutCfgLock.Lock()
+	defer timeoutCfgLock.Unlock()
+	pluginRequestTimeout = t
+}
+
+func getPluginRequestTimeout() time.Duration {
+	timeoutCfgLock.RLock()
+	defer timeoutCfgLock.RUnlock()
+	return pluginRequestTimeout
 }
 
 // Launch a pre-installed plugin with a pre-connected socketpair.
@@ -210,7 +244,10 @@ func (p *plugin) connect(conn stdnet.Conn) (retErr error) {
 
 // Start Runtime service, wait for plugin to register, then configure it.
 func (p *plugin) start(name, version string) error {
-	var err error
+	var (
+		err     error
+		timeout = getPluginRegistrationTimeout()
+	)
 
 	go func() {
 		err := p.rpcs.Serve(context.Background(), p.rpcl)
@@ -229,7 +266,7 @@ func (p *plugin) start(name, version string) error {
 		}
 	case <-p.closeC:
 		return fmt.Errorf("failed to register plugin, connection closed")
-	case <-time.After(pluginRegistrationTimeout):
+	case <-time.After(timeout):
 		p.close()
 		p.stop()
 		return errors.New("plugin registration timed out")
@@ -339,7 +376,7 @@ func (p *plugin) UpdateContainers(ctx context.Context, req *UpdateContainersRequ
 
 // configure the plugin and subscribe it for the events it requested.
 func (p *plugin) configure(ctx context.Context, name, version, config string) error {
-	ctx, cancel := context.WithTimeout(ctx, pluginRequestTimeout)
+	ctx, cancel := context.WithTimeout(ctx, getPluginRequestTimeout())
 	defer cancel()
 
 	rpl, err := p.stub.Configure(ctx, &ConfigureRequest{
@@ -368,7 +405,7 @@ func (p *plugin) configure(ctx context.Context, name, version, config string) er
 func (p *plugin) synchronize(ctx context.Context, pods []*PodSandbox, containers []*Container) ([]*ContainerUpdate, error) {
 	log.Infof(ctx, "synchronizing plugin %s", p.name())
 
-	ctx, cancel := context.WithTimeout(ctx, pluginRequestTimeout)
+	ctx, cancel := context.WithTimeout(ctx, getPluginRequestTimeout())
 	defer cancel()
 
 	req := &SynchronizeRequest{
@@ -389,7 +426,7 @@ func (p *plugin) createContainer(ctx context.Context, req *CreateContainerReques
 		return nil, nil
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, pluginRequestTimeout)
+	ctx, cancel := context.WithTimeout(ctx, getPluginRequestTimeout())
 	defer cancel()
 
 	rpl, err := p.stub.CreateContainer(ctx, req)
@@ -412,7 +449,7 @@ func (p *plugin) updateContainer(ctx context.Context, req *UpdateContainerReques
 		return nil, nil
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, pluginRequestTimeout)
+	ctx, cancel := context.WithTimeout(ctx, getPluginRequestTimeout())
 	defer cancel()
 
 	rpl, err := p.stub.UpdateContainer(ctx, req)
@@ -435,7 +472,7 @@ func (p *plugin) stopContainer(ctx context.Context, req *StopContainerRequest) (
 		return nil, nil
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, pluginRequestTimeout)
+	ctx, cancel := context.WithTimeout(ctx, getPluginRequestTimeout())
 	defer cancel()
 
 	rpl, err := p.stub.StopContainer(ctx, req)
@@ -458,7 +495,7 @@ func (p *plugin) StateChange(ctx context.Context, evt *StateChangeEvent) error {
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, pluginRequestTimeout)
+	ctx, cancel := context.WithTimeout(ctx, getPluginRequestTimeout())
 	defer cancel()
 
 	_, err := p.stub.StateChange(ctx, evt)

--- a/pkg/api/plugin.go
+++ b/pkg/api/plugin.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	// DefaultSocketPath is the default socket path for external plugins.
-	DefaultSocketPath = "/var/run/nri.sock"
+	DefaultSocketPath = "/var/run/nri/nri.sock"
 	// PluginSocketEnvVar is used to inform plugins about pre-connected sockets.
 	PluginSocketEnvVar = "NRI_PLUGIN_SOCKET"
 	// PluginNameEnvVar is used to inform NRI-launched plugins about their name.


### PR DESCRIPTION
Update defaults for plugin registration and request processing timeouts and make them configurable. This should help testing plugins with a complex startup/registration sequence in very slow CI environments where registration otherwise sometimes triggers a timeout.

Also adjust the default socket path to `/var/run/nri/nri.sock` and create the parent directory for the socket with `0700` access rights instead of `0755`. Having an intermediate directory makes it easier for plugins that run as a K8s daemonset to survive a runtime restart an reconnect to the NRI socket. 