### PR TITLE
adaptation: fix mount and device adjustment.

### DIFF
--- a/pkg/adaptation/result.go
+++ b/pkg/adaptation/result.go
@@ -316,9 +316,7 @@ func (r *result) adjustMounts(mounts []*Mount, plugin string) error {
 	}
 
 	// finally, apply additions/modifications to plugin container creation request
-	for _, m := range add {
-		create.Container.Mounts = append(r.reply.adjust.Mounts, m)
-	}
+	create.Container.Mounts = append(create.Container.Mounts, add...)
 
 	return nil
 }
@@ -376,9 +374,7 @@ func (r *result) adjustDevices(devices []*LinuxDevice, plugin string) error {
 	}
 
 	// finally, apply additions/modifications to plugin container creation request
-	for _, d := range add {
-		create.Container.Linux.Devices = append(r.reply.adjust.Linux.Devices, d)
-	}
+	create.Container.Linux.Devices = append(create.Container.Linux.Devices, add...)
 
 	return nil
 }


### PR DESCRIPTION
Fix mount and device adjustment for container create request processing. Mounts in the NRI create request got incorrectly reset if a plugin ever modifed mounts. All subsequent plugins received incorrect mount data in their creation request. The same bug was present for device adjustment.

Note that this had a direct effect on the NRI creation request but not the actual container itself.