### PR TITLE
fixes: sort final adjusted mount slice.

### DIFF
--- a/pkg/api/mount.go
+++ b/pkg/api/mount.go
@@ -47,7 +47,6 @@ func (m *Mount) ToOCI(propagationQuery *string) rspec.Mount {
 		Destination: m.Destination,
 		Type:        m.Type,
 		Source:      m.Source,
-		Options:     []string{},
 	}
 	for _, opt := range m.Options {
 		o.Options = append(o.Options, opt)


### PR DESCRIPTION
If mounts get adjusted, sort the final mount slice to make sure that any potential subdirectories are mounted only after their parents. Otherwise a parent mount could shadow/mask the content of a previously mounted subdirectory.