### PR TITLE
Add Go 1.20 support to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19.x
+          go-version: 1.20.x
 
       - name: Set env
         shell: bash
@@ -40,13 +40,17 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.19.x]
+        go: [1.19.x, 1.20.x]
         os: [ubuntu-22.04]
 
     steps:
       - uses: actions/checkout@v3
         with:
           path: src/github.com/containerd/nri
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
 
       - name: Set env
         shell: bash
@@ -56,13 +60,17 @@ jobs:
 
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.50.1
+          version: v1.51.2
           working-directory: src/github.com/containerd/nri
 
   tests:
     name: Tests
     runs-on: ubuntu-22.04
     timeout-minutes: 5
+
+    strategy:
+      matrix:
+        go: [1.19.x, 1.20.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -71,7 +79,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19.x
+          go-version: ${{ matrix.go }}
 
       - name: Set env
         shell: bash

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/nri
 
-go 1.18
+go 1.19
 
 // when updating containerd, adjust the replace rules accordingly
 require (


### PR DESCRIPTION
Update minimum Go version to Go 1.19 in go.mod. Update golangci-lint to
v1.51.x for Go 1.20 support.

Signed-off-by: Austin Vazquez <macedonv@amazon.com>