### PR TITLE
api: initialize OCI LinuxMemory resources to empty.

### DIFF
--- a/pkg/api/resources.go
+++ b/pkg/api/resources.go
@@ -100,7 +100,10 @@ func (r *LinuxResources) ToOCI() *rspec.LinuxResources {
 	if r == nil {
 		return nil
 	}
-	o := &rspec.LinuxResources{}
+	o := &rspec.LinuxResources{
+		CPU:    &rspec.LinuxCPU{},
+		Memory: &rspec.LinuxMemory{},
+	}
 	if r.Memory != nil {
 		o.Memory = &rspec.LinuxMemory{
 			Limit:            r.Memory.Limit.Get(),


### PR DESCRIPTION
When converting to OCI LinuxResources, always use an empty `&LinuxMemory{}` instead of a `nil` one. Some runtimes try to dereference it unconditionally. Leaving it unset panics on these.