### PR TITLE
Makefile: fix 'install-*' targets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,13 +165,13 @@ golangci-lint:
 #
 
 install-protoc install-protobuf:
-	$(Q)./scripts/install-protobuf && \
+	$(Q)./scripts/install-protobuf
 
 install-ttrpc-plugin:
-	$(Q)$(GO_INSTALL) github.com/containerd/ttrpc/cmd/protoc-gen-go-ttrpc@74421d10189e8c118870d294c9f7f62db2d33ec1
+	$(Q)$(GO_INSTALL) -mod=mod github.com/containerd/ttrpc/cmd/protoc-gen-go-ttrpc@74421d10189e8c118870d294c9f7f62db2d33ec1
 
 install-protoc-dependencies:
-	$(Q)$(GO_INSTALL) google.golang.org/protobuf/cmd/protoc-gen-go@v1.28.0
+	$(Q)$(GO_INSTALL) -mod=mod google.golang.org/protobuf/cmd/protoc-gen-go@v1.28.0
 
 install-ginkgo:
 	$(Q)$(GO_INSTALL) -mod=mod github.com/onsi/ginkgo/v2/ginkgo


### PR DESCRIPTION
Fix 'install-*' Makefile targets to properly install and compile the various protoc toolchain binaries and plugins.