### PR TITLE
Fix ParseEventMask to produce proper masks for 'pod' and 'container' shorthand event notations.

### DIFF
--- a/pkg/api/event.go
+++ b/pkg/api/event.go
@@ -82,14 +82,14 @@ func ParseEventMask(events ...string) (EventMask, error) {
 				continue
 			case "pod", "podsandbox":
 				for name, bit := range bits {
-					if strings.Contains(name, "Pod") {
+					if strings.Contains(name, "pod") {
 						mask.Set(bit)
 					}
 				}
 				continue
 			case "container":
 				for name, bit := range bits {
-					if strings.Contains(name, "Container") {
+					if strings.Contains(name, "container") {
 						mask.Set(bit)
 					}
 				}


### PR DESCRIPTION
 the keys in code's bits map is lowercase
```
bits := map[string]Event{
		"runpodsandbox":       Event_RUN_POD_SANDBOX,
		"stoppodsandbox":      Event_STOP_POD_SANDBOX,
		"removepodsandbox":    Event_REMOVE_POD_SANDBOX,
		"createcontainer":     Event_CREATE_CONTAINER,
		"postcreatecontainer": Event_POST_CREATE_CONTAINER,
		"startcontainer":      Event_START_CONTAINER,
		"poststartcontainer":  Event_POST_START_CONTAINER,
		"updatecontainer":     Event_UPDATE_CONTAINER,
		"postupdatecontainer": Event_POST_UPDATE_CONTAINER,
		"stopcontainer":       Event_STOP_CONTAINER,
		"removecontainer":     Event_REMOVE_CONTAINER,
	}
```

so should fix if strings.Contains(name, "Pod") => if strings.Contains(name, "pod")