### PR TITLE
stub: pass context to plugins, pass updated resources to UpdateContainers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,17 @@ access to these sockets and can act as NRI or Device Plugins. See the
 and [best practices](https://kubernetes.io/docs/setup/best-practices/enforcing-pod-security-standards/)
 about Kubernetes security.
 
+## API Stability
+
+NRI APIs should not be considered stable yet. We try to avoid unnecessarily
+breaking APIs, especially the Stub API which plugins use to interact with NRI.
+However, before NRI reaches a stable 1.0.0 release, this is only best effort
+and cannot be guaranteed. Meanwhile we do our best to document any API breaking
+changes for each release in the [release notes](RELEASES.md).
+
+The current target for a stable v1 API through a 1.0.0 release is the end of
+this year.
+
 ## Project details
 
 nri is a containerd sub-project, licensed under the [Apache 2.0 license](./LICENSE).

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,0 +1,32 @@
+# Release Notes
+
+## 0.4.0 (pending untagged release)
+
+- Pass the ttRPC receiving context from the Stub to each NRI request handler
+of the plugin.
+- Fix Stub/Plugin UpdateContainer interface to pass the resource update to
+the UpdateContainer NRI request handler of the plugin as the last argument.
+- All plugins need to be updated to reflect the above changes in any NRI
+request handler they implement.
+
+## 0.3.0
+
+- Eliminate the global NRI configuration file, replacing any remaining
+configuration options with corresponding programmatic options for runtimes.
+- Change default socket path from /var/run/nri.sock to /var/run/nri/nri.sock.
+- Make plugin timeouts configurable on the runtime side.
+- Plugins should be API-compatible between 0.2.0 and 0.3.0, but either the
+runtime needs to be configured to use the old NRI socket path, or 0.2.0 plugins
+need to be configured to use the new default NRI socket path.
+
+## 0.2.0
+
+- Replace the v0.1.0 CNI like plugin interface with JSON message exchange on
+stdin and stdout with external daemon-like plugins and a protobuf-defined
+protocol with ttRPC bindings for communicating with the runtime.
+- Allow plugins to track the state of (CRI) pods and containers.
+- Allow plugins to make changes to a selected subset of container parameters
+during container creation, update, and stopping of (other) containers.
+- All 0.1.0 plugins are incompatible with 0.2.0, although
+[an experimental adapter plugin](plugins/v010-adapter) is provided to bridge
+between any existing 0.1.0 plugins and the current NRI APIs.

--- a/pkg/adaptation/suite_test.go
+++ b/pkg/adaptation/suite_test.go
@@ -470,13 +470,13 @@ func (m *mockPlugin) onClose() {
 	}
 }
 
-func (m *mockPlugin) Configure(cfg, runtime, version string) (stub.EventMask, error) {
+func (m *mockPlugin) Configure(_ context.Context, cfg, runtime, version string) (stub.EventMask, error) {
 	m.q.Add(PluginConfigured)
 
 	return m.mask, nil
 }
 
-func (m *mockPlugin) Synchronize(pods []*api.PodSandbox, ctrs []*api.Container) ([]*api.ContainerUpdate, error) {
+func (m *mockPlugin) Synchronize(_ context.Context, pods []*api.PodSandbox, ctrs []*api.Container) ([]*api.ContainerUpdate, error) {
 	for _, pod := range pods {
 		m.pods[pod.Id] = pod
 	}
@@ -489,32 +489,32 @@ func (m *mockPlugin) Synchronize(pods []*api.PodSandbox, ctrs []*api.Container) 
 	return nil, nil
 }
 
-func (m *mockPlugin) Shutdown() {
+func (m *mockPlugin) Shutdown(_ context.Context) {
 	m.q.Add(PluginShutdown)
 }
 
-func (m *mockPlugin) RunPodSandbox(pod *api.PodSandbox) error {
+func (m *mockPlugin) RunPodSandbox(_ context.Context, pod *api.PodSandbox) error {
 	m.pods[pod.Id] = pod
 	err := m.runPodSandbox(m, pod, nil)
 	m.q.Add(PodSandboxEvent(pod, RunPodSandbox))
 	return err
 }
 
-func (m *mockPlugin) StopPodSandbox(pod *api.PodSandbox) error {
+func (m *mockPlugin) StopPodSandbox(_ context.Context, pod *api.PodSandbox) error {
 	m.pods[pod.Id] = pod
 	err := m.stopPodSandbox(m, pod, nil)
 	m.q.Add(PodSandboxEvent(pod, StopPodSandbox))
 	return err
 }
 
-func (m *mockPlugin) RemovePodSandbox(pod *api.PodSandbox) error {
+func (m *mockPlugin) RemovePodSandbox(_ context.Context, pod *api.PodSandbox) error {
 	delete(m.pods, pod.Id)
 	err := m.removePodSandbox(m, pod, nil)
 	m.q.Add(PodSandboxEvent(pod, RemovePodSandbox))
 	return err
 }
 
-func (m *mockPlugin) CreateContainer(pod *api.PodSandbox, ctr *api.Container) (*api.ContainerAdjustment, []*api.ContainerUpdate, error) {
+func (m *mockPlugin) CreateContainer(_ context.Context, pod *api.PodSandbox, ctr *api.Container) (*api.ContainerAdjustment, []*api.ContainerUpdate, error) {
 	m.pods[pod.Id] = pod
 	m.ctrs[ctr.Id] = ctr
 	m.q.Add(ContainerEvent(ctr, CreateContainer))
@@ -522,7 +522,7 @@ func (m *mockPlugin) CreateContainer(pod *api.PodSandbox, ctr *api.Container) (*
 	return m.createContainer(m, pod, ctr)
 }
 
-func (m *mockPlugin) PostCreateContainer(pod *api.PodSandbox, ctr *api.Container) error {
+func (m *mockPlugin) PostCreateContainer(_ context.Context, pod *api.PodSandbox, ctr *api.Container) error {
 	m.pods[pod.Id] = pod
 	m.ctrs[ctr.Id] = ctr
 	m.q.Add(ContainerEvent(ctr, PostCreateContainer))
@@ -530,7 +530,7 @@ func (m *mockPlugin) PostCreateContainer(pod *api.PodSandbox, ctr *api.Container
 	return m.postCreateContainer(m, pod, ctr)
 }
 
-func (m *mockPlugin) StartContainer(pod *api.PodSandbox, ctr *api.Container) error {
+func (m *mockPlugin) StartContainer(_ context.Context, pod *api.PodSandbox, ctr *api.Container) error {
 	m.pods[pod.Id] = pod
 	m.ctrs[ctr.Id] = ctr
 	m.q.Add(ContainerEvent(ctr, StartContainer))
@@ -538,7 +538,7 @@ func (m *mockPlugin) StartContainer(pod *api.PodSandbox, ctr *api.Container) err
 	return m.startContainer(m, pod, ctr)
 }
 
-func (m *mockPlugin) PostStartContainer(pod *api.PodSandbox, ctr *api.Container) error {
+func (m *mockPlugin) PostStartContainer(_ context.Context, pod *api.PodSandbox, ctr *api.Container) error {
 	m.pods[pod.Id] = pod
 	m.ctrs[ctr.Id] = ctr
 	m.q.Add(ContainerEvent(ctr, PostStartContainer))
@@ -546,7 +546,7 @@ func (m *mockPlugin) PostStartContainer(pod *api.PodSandbox, ctr *api.Container)
 	return m.postStartContainer(m, pod, ctr)
 }
 
-func (m *mockPlugin) UpdateContainer(pod *api.PodSandbox, ctr *api.Container) ([]*api.ContainerUpdate, error) {
+func (m *mockPlugin) UpdateContainer(_ context.Context, pod *api.PodSandbox, ctr *api.Container) ([]*api.ContainerUpdate, error) {
 	m.pods[pod.Id] = pod
 	m.ctrs[ctr.Id] = ctr
 	m.q.Add(ContainerEvent(ctr, UpdateContainer))
@@ -554,7 +554,7 @@ func (m *mockPlugin) UpdateContainer(pod *api.PodSandbox, ctr *api.Container) ([
 	return m.updateContainer(m, pod, ctr)
 }
 
-func (m *mockPlugin) PostUpdateContainer(pod *api.PodSandbox, ctr *api.Container) error {
+func (m *mockPlugin) PostUpdateContainer(_ context.Context, pod *api.PodSandbox, ctr *api.Container) error {
 	m.pods[pod.Id] = pod
 	m.ctrs[ctr.Id] = ctr
 	m.q.Add(ContainerEvent(ctr, PostUpdateContainer))
@@ -562,7 +562,7 @@ func (m *mockPlugin) PostUpdateContainer(pod *api.PodSandbox, ctr *api.Container
 	return m.postUpdateContainer(m, pod, ctr)
 }
 
-func (m *mockPlugin) StopContainer(pod *api.PodSandbox, ctr *api.Container) ([]*api.ContainerUpdate, error) {
+func (m *mockPlugin) StopContainer(_ context.Context, pod *api.PodSandbox, ctr *api.Container) ([]*api.ContainerUpdate, error) {
 	m.pods[pod.Id] = pod
 	m.ctrs[ctr.Id] = ctr
 	m.q.Add(ContainerEvent(ctr, StopContainer))
@@ -570,7 +570,7 @@ func (m *mockPlugin) StopContainer(pod *api.PodSandbox, ctr *api.Container) ([]*
 	return m.stopContainer(m, pod, ctr)
 }
 
-func (m *mockPlugin) RemoveContainer(pod *api.PodSandbox, ctr *api.Container) error {
+func (m *mockPlugin) RemoveContainer(_ context.Context, pod *api.PodSandbox, ctr *api.Container) error {
 	delete(m.ctrs, ctr.Id)
 	m.q.Add(ContainerEvent(ctr, RemoveContainer))
 

--- a/pkg/adaptation/suite_test.go
+++ b/pkg/adaptation/suite_test.go
@@ -316,7 +316,7 @@ type mockPlugin struct {
 	postCreateContainer func(*mockPlugin, *api.PodSandbox, *api.Container) error
 	startContainer      func(*mockPlugin, *api.PodSandbox, *api.Container) error
 	postStartContainer  func(*mockPlugin, *api.PodSandbox, *api.Container) error
-	updateContainer     func(*mockPlugin, *api.PodSandbox, *api.Container) ([]*api.ContainerUpdate, error)
+	updateContainer     func(*mockPlugin, *api.PodSandbox, *api.Container, *api.LinuxResources) ([]*api.ContainerUpdate, error)
 	postUpdateContainer func(*mockPlugin, *api.PodSandbox, *api.Container) error
 	stopContainer       func(*mockPlugin, *api.PodSandbox, *api.Container) ([]*api.ContainerUpdate, error)
 	removeContainer     func(*mockPlugin, *api.PodSandbox, *api.Container) error
@@ -546,12 +546,12 @@ func (m *mockPlugin) PostStartContainer(_ context.Context, pod *api.PodSandbox, 
 	return m.postStartContainer(m, pod, ctr)
 }
 
-func (m *mockPlugin) UpdateContainer(_ context.Context, pod *api.PodSandbox, ctr *api.Container) ([]*api.ContainerUpdate, error) {
+func (m *mockPlugin) UpdateContainer(_ context.Context, pod *api.PodSandbox, ctr *api.Container, res *api.LinuxResources) ([]*api.ContainerUpdate, error) {
 	m.pods[pod.Id] = pod
 	m.ctrs[ctr.Id] = ctr
 	m.q.Add(ContainerEvent(ctr, UpdateContainer))
 
-	return m.updateContainer(m, pod, ctr)
+	return m.updateContainer(m, pod, ctr, res)
 }
 
 func (m *mockPlugin) PostUpdateContainer(_ context.Context, pod *api.PodSandbox, ctr *api.Container) error {
@@ -585,7 +585,7 @@ func nopCreateContainer(*mockPlugin, *api.PodSandbox, *api.Container) (*api.Cont
 	return nil, nil, nil
 }
 
-func nopUpdateContainer(*mockPlugin, *api.PodSandbox, *api.Container) ([]*api.ContainerUpdate, error) {
+func nopUpdateContainer(*mockPlugin, *api.PodSandbox, *api.Container, *api.LinuxResources) ([]*api.ContainerUpdate, error) {
 	return nil, nil
 }
 

--- a/pkg/stub/stub.go
+++ b/pkg/stub/stub.go
@@ -101,7 +101,7 @@ type UpdateContainerInterface interface {
 	// The plugin can request updates both to the container being updated
 	// (which then supersedes the original update) and to other unstopped
 	// containers in response.
-	UpdateContainer(context.Context, *api.PodSandbox, *api.Container) ([]*api.ContainerUpdate, error)
+	UpdateContainer(context.Context, *api.PodSandbox, *api.Container, *api.LinuxResources) ([]*api.ContainerUpdate, error)
 }
 
 // StopContainerInterface handles StopContainer API requests.
@@ -261,7 +261,7 @@ type handlers struct {
 	RemovePodSandbox    func(context.Context, *api.PodSandbox) error
 	CreateContainer     func(context.Context, *api.PodSandbox, *api.Container) (*api.ContainerAdjustment, []*api.ContainerUpdate, error)
 	StartContainer      func(context.Context, *api.PodSandbox, *api.Container) error
-	UpdateContainer     func(context.Context, *api.PodSandbox, *api.Container) ([]*api.ContainerUpdate, error)
+	UpdateContainer     func(context.Context, *api.PodSandbox, *api.Container, *api.LinuxResources) ([]*api.ContainerUpdate, error)
 	StopContainer       func(context.Context, *api.PodSandbox, *api.Container) ([]*api.ContainerUpdate, error)
 	RemoveContainer     func(context.Context, *api.PodSandbox, *api.Container) error
 	PostCreateContainer func(context.Context, *api.PodSandbox, *api.Container) error
@@ -619,7 +619,7 @@ func (stub *stub) UpdateContainer(ctx context.Context, req *api.UpdateContainerR
 	if handler == nil {
 		return nil, nil
 	}
-	update, err := handler(ctx, req.Pod, req.Container)
+	update, err := handler(ctx, req.Pod, req.Container, req.LinuxResources)
 	return &api.UpdateContainerResponse{
 		Update: update,
 	}, err

--- a/pkg/stub/stub.go
+++ b/pkg/stub/stub.go
@@ -47,38 +47,38 @@ type ConfigureInterface interface {
 	// Configure the plugin with the given NRI-supplied configuration.
 	// If a non-zero EventMask is returned, the plugin will be subscribed
 	// to the corresponding.
-	Configure(config, runtime, version string) (api.EventMask, error)
+	Configure(ctx context.Context, config, runtime, version string) (api.EventMask, error)
 }
 
 // SynchronizeInterface handles Synchronize API requests.
 type SynchronizeInterface interface {
 	// Synchronize the state of the plugin with the runtime.
 	// The plugin can request updates to containers in response.
-	Synchronize([]*api.PodSandbox, []*api.Container) ([]*api.ContainerUpdate, error)
+	Synchronize(context.Context, []*api.PodSandbox, []*api.Container) ([]*api.ContainerUpdate, error)
 }
 
 // ShutdownInterface handles a Shutdown API request.
 type ShutdownInterface interface {
 	// Shutdown notifies the plugin about the runtime shutting down.
-	Shutdown(*api.ShutdownRequest)
+	Shutdown(context.Context)
 }
 
 // RunPodInterface handles RunPodSandbox API events.
 type RunPodInterface interface {
 	// RunPodSandbox relays a RunPodSandbox event to the plugin.
-	RunPodSandbox(*api.PodSandbox) error
+	RunPodSandbox(context.Context, *api.PodSandbox) error
 }
 
 // StopPodInterface handles StopPodSandbox API events.
 type StopPodInterface interface {
 	// StopPodSandbox relays a StopPodSandbox event to the plugin.
-	StopPodSandbox(*api.PodSandbox) error
+	StopPodSandbox(context.Context, *api.PodSandbox) error
 }
 
 // RemovePodInterface handles RemovePodSandbox API events.
 type RemovePodInterface interface {
 	// RemovePodSandbox relays a RemovePodSandbox event to the plugin.
-	RemovePodSandbox(*api.PodSandbox) error
+	RemovePodSandbox(context.Context, *api.PodSandbox) error
 }
 
 // CreateContainerInterface handles CreateContainer API requests.
@@ -86,13 +86,13 @@ type CreateContainerInterface interface {
 	// CreateContainer relays a CreateContainer request to the plugin.
 	// The plugin can request adjustments to the container being created
 	// and updates to other unstopped containers in response.
-	CreateContainer(*api.PodSandbox, *api.Container) (*api.ContainerAdjustment, []*api.ContainerUpdate, error)
+	CreateContainer(context.Context, *api.PodSandbox, *api.Container) (*api.ContainerAdjustment, []*api.ContainerUpdate, error)
 }
 
 // StartContainerInterface handles StartContainer API requests.
 type StartContainerInterface interface {
 	// StartContainer relays a StartContainer event to the plugin.
-	StartContainer(*api.PodSandbox, *api.Container) error
+	StartContainer(context.Context, *api.PodSandbox, *api.Container) error
 }
 
 // UpdateContainerInterface handles UpdateContainer API requests.
@@ -101,38 +101,38 @@ type UpdateContainerInterface interface {
 	// The plugin can request updates both to the container being updated
 	// (which then supersedes the original update) and to other unstopped
 	// containers in response.
-	UpdateContainer(*api.PodSandbox, *api.Container) ([]*api.ContainerUpdate, error)
+	UpdateContainer(context.Context, *api.PodSandbox, *api.Container) ([]*api.ContainerUpdate, error)
 }
 
 // StopContainerInterface handles StopContainer API requests.
 type StopContainerInterface interface {
 	// StopContainer relays a StopContainer request to the plugin.
 	// The plugin can request updates to unstopped containers in response.
-	StopContainer(*api.PodSandbox, *api.Container) ([]*api.ContainerUpdate, error)
+	StopContainer(context.Context, *api.PodSandbox, *api.Container) ([]*api.ContainerUpdate, error)
 }
 
 // RemoveContainerInterface handles RemoveContainer API events.
 type RemoveContainerInterface interface {
 	// RemoveContainer relays a RemoveContainer event to the plugin.
-	RemoveContainer(*api.PodSandbox, *api.Container) error
+	RemoveContainer(context.Context, *api.PodSandbox, *api.Container) error
 }
 
 // PostCreateContainerInterface handles PostCreateContainer API events.
 type PostCreateContainerInterface interface {
 	// PostCreateContainer relays a PostCreateContainer event to the plugin.
-	PostCreateContainer(*api.PodSandbox, *api.Container) error
+	PostCreateContainer(context.Context, *api.PodSandbox, *api.Container) error
 }
 
 // PostStartContainerInterface handles PostStartContainer API events.
 type PostStartContainerInterface interface {
 	// PostStartContainer relays a PostStartContainer event to the plugin.
-	PostStartContainer(*api.PodSandbox, *api.Container) error
+	PostStartContainer(context.Context, *api.PodSandbox, *api.Container) error
 }
 
 // PostUpdateContainerInterface handles PostUpdateContainer API events.
 type PostUpdateContainerInterface interface {
 	// PostUpdateContainer relays a PostUpdateContainer event to the plugin.
-	PostUpdateContainer(*api.PodSandbox, *api.Container) error
+	PostUpdateContainer(context.Context, *api.PodSandbox, *api.Container) error
 }
 
 // Stub is the interface the stub provides for the plugin implementation.
@@ -253,20 +253,20 @@ type stub struct {
 
 // Handlers for NRI plugin event and request.
 type handlers struct {
-	Configure           func(string, string, string) (api.EventMask, error)
-	Synchronize         func([]*api.PodSandbox, []*api.Container) ([]*api.ContainerUpdate, error)
-	Shutdown            func(*api.ShutdownRequest)
-	RunPodSandbox       func(*api.PodSandbox) error
-	StopPodSandbox      func(*api.PodSandbox) error
-	RemovePodSandbox    func(*api.PodSandbox) error
-	CreateContainer     func(*api.PodSandbox, *api.Container) (*api.ContainerAdjustment, []*api.ContainerUpdate, error)
-	StartContainer      func(*api.PodSandbox, *api.Container) error
-	UpdateContainer     func(*api.PodSandbox, *api.Container) ([]*api.ContainerUpdate, error)
-	StopContainer       func(*api.PodSandbox, *api.Container) ([]*api.ContainerUpdate, error)
-	RemoveContainer     func(*api.PodSandbox, *api.Container) error
-	PostCreateContainer func(*api.PodSandbox, *api.Container) error
-	PostStartContainer  func(*api.PodSandbox, *api.Container) error
-	PostUpdateContainer func(*api.PodSandbox, *api.Container) error
+	Configure           func(context.Context, string, string, string) (api.EventMask, error)
+	Synchronize         func(context.Context, []*api.PodSandbox, []*api.Container) ([]*api.ContainerUpdate, error)
+	Shutdown            func(context.Context)
+	RunPodSandbox       func(context.Context, *api.PodSandbox) error
+	StopPodSandbox      func(context.Context, *api.PodSandbox) error
+	RemovePodSandbox    func(context.Context, *api.PodSandbox) error
+	CreateContainer     func(context.Context, *api.PodSandbox, *api.Container) (*api.ContainerAdjustment, []*api.ContainerUpdate, error)
+	StartContainer      func(context.Context, *api.PodSandbox, *api.Container) error
+	UpdateContainer     func(context.Context, *api.PodSandbox, *api.Container) ([]*api.ContainerUpdate, error)
+	StopContainer       func(context.Context, *api.PodSandbox, *api.Container) ([]*api.ContainerUpdate, error)
+	RemoveContainer     func(context.Context, *api.PodSandbox, *api.Container) error
+	PostCreateContainer func(context.Context, *api.PodSandbox, *api.Container) error
+	PostStartContainer  func(context.Context, *api.PodSandbox, *api.Container) error
+	PostUpdateContainer func(context.Context, *api.PodSandbox, *api.Container) error
 }
 
 // New creates a stub with the given plugin and options.
@@ -552,7 +552,7 @@ func (stub *stub) Configure(ctx context.Context, req *api.ConfigureRequest) (rpl
 	if handler := stub.handlers.Configure; handler == nil {
 		events = stub.events
 	} else {
-		events, err = handler(req.Config, req.RuntimeName, req.RuntimeVersion)
+		events, err = handler(ctx, req.Config, req.RuntimeName, req.RuntimeVersion)
 		if err != nil {
 			log.Errorf(ctx, "Plugin configuration failed: %v", err)
 			return nil, err
@@ -585,7 +585,7 @@ func (stub *stub) Synchronize(ctx context.Context, req *api.SynchronizeRequest) 
 	if handler == nil {
 		return &api.SynchronizeResponse{}, nil
 	}
-	update, err := handler(req.Pods, req.Containers)
+	update, err := handler(ctx, req.Pods, req.Containers)
 	return &api.SynchronizeResponse{
 		Update: update,
 	}, err
@@ -595,7 +595,7 @@ func (stub *stub) Synchronize(ctx context.Context, req *api.SynchronizeRequest) 
 func (stub *stub) Shutdown(ctx context.Context, req *api.ShutdownRequest) (*api.ShutdownResponse, error) {
 	handler := stub.handlers.Shutdown
 	if handler != nil {
-		handler(req)
+		handler(ctx)
 	}
 	return &api.ShutdownResponse{}, nil
 }
@@ -606,7 +606,7 @@ func (stub *stub) CreateContainer(ctx context.Context, req *api.CreateContainerR
 	if handler == nil {
 		return nil, nil
 	}
-	adjust, update, err := handler(req.Pod, req.Container)
+	adjust, update, err := handler(ctx, req.Pod, req.Container)
 	return &api.CreateContainerResponse{
 		Adjust: adjust,
 		Update: update,
@@ -619,7 +619,7 @@ func (stub *stub) UpdateContainer(ctx context.Context, req *api.UpdateContainerR
 	if handler == nil {
 		return nil, nil
 	}
-	update, err := handler(req.Pod, req.Container)
+	update, err := handler(ctx, req.Pod, req.Container)
 	return &api.UpdateContainerResponse{
 		Update: update,
 	}, err
@@ -631,7 +631,7 @@ func (stub *stub) StopContainer(ctx context.Context, req *api.StopContainerReque
 	if handler == nil {
 		return nil, nil
 	}
-	update, err := handler(req.Pod, req.Container)
+	update, err := handler(ctx, req.Pod, req.Container)
 	return &api.StopContainerResponse{
 		Update: update,
 	}, err
@@ -643,35 +643,35 @@ func (stub *stub) StateChange(ctx context.Context, evt *api.StateChangeEvent) (*
 	switch evt.Event {
 	case api.Event_RUN_POD_SANDBOX:
 		if handler := stub.handlers.RunPodSandbox; handler != nil {
-			err = handler(evt.Pod)
+			err = handler(ctx, evt.Pod)
 		}
 	case api.Event_STOP_POD_SANDBOX:
 		if handler := stub.handlers.StopPodSandbox; handler != nil {
-			err = handler(evt.Pod)
+			err = handler(ctx, evt.Pod)
 		}
 	case api.Event_REMOVE_POD_SANDBOX:
 		if handler := stub.handlers.RemovePodSandbox; handler != nil {
-			err = handler(evt.Pod)
+			err = handler(ctx, evt.Pod)
 		}
 	case api.Event_POST_CREATE_CONTAINER:
 		if handler := stub.handlers.PostCreateContainer; handler != nil {
-			err = handler(evt.Pod, evt.Container)
+			err = handler(ctx, evt.Pod, evt.Container)
 		}
 	case api.Event_START_CONTAINER:
 		if handler := stub.handlers.StartContainer; handler != nil {
-			err = handler(evt.Pod, evt.Container)
+			err = handler(ctx, evt.Pod, evt.Container)
 		}
 	case api.Event_POST_START_CONTAINER:
 		if handler := stub.handlers.PostStartContainer; handler != nil {
-			err = handler(evt.Pod, evt.Container)
+			err = handler(ctx, evt.Pod, evt.Container)
 		}
 	case api.Event_POST_UPDATE_CONTAINER:
 		if handler := stub.handlers.PostUpdateContainer; handler != nil {
-			err = handler(evt.Pod, evt.Container)
+			err = handler(ctx, evt.Pod, evt.Container)
 		}
 	case api.Event_REMOVE_CONTAINER:
 		if handler := stub.handlers.RemoveContainer; handler != nil {
-			err = handler(evt.Pod, evt.Container)
+			err = handler(ctx, evt.Pod, evt.Container)
 		}
 	}
 

--- a/plugins/device-injector/device-injector.go
+++ b/plugins/device-injector/device-injector.go
@@ -67,7 +67,7 @@ type plugin struct {
 }
 
 // CreateContainer handles container creation requests.
-func (p *plugin) CreateContainer(pod *api.PodSandbox, container *api.Container) (*api.ContainerAdjustment, []*api.ContainerUpdate, error) {
+func (p *plugin) CreateContainer(_ context.Context, pod *api.PodSandbox, container *api.Container) (*api.ContainerAdjustment, []*api.ContainerUpdate, error) {
 	var (
 		ctrName string
 		devices []device

--- a/plugins/differ/nri-differ.go
+++ b/plugins/differ/nri-differ.go
@@ -227,7 +227,7 @@ func (p *plugin) PostStartContainer(_ context.Context, pod *api.PodSandbox, cont
 	return nil
 }
 
-func (p *plugin) UpdateContainer(_ context.Context, pod *api.PodSandbox, container *api.Container) ([]*api.ContainerUpdate, error) {
+func (p *plugin) UpdateContainer(_ context.Context, pod *api.PodSandbox, container *api.Container, r *api.LinuxResources) ([]*api.ContainerUpdate, error) {
 	p.differ("UpdateContainer", pod, container)
 
 	return nil, nil

--- a/plugins/differ/nri-differ.go
+++ b/plugins/differ/nri-differ.go
@@ -68,7 +68,7 @@ var (
 	indices map[int]pluginIndex
 )
 
-func (p *plugin) Configure(nriCfg string) (stub.EventMask, error) {
+func (p *plugin) Configure(_ context.Context, nriCfg string) (stub.EventMask, error) {
 	log.Infof("got configuration data: %q", nriCfg)
 	if nriCfg == "" {
 		return p.mask, nil
@@ -177,7 +177,7 @@ func (p *plugin) differ(apifunc string, pod *api.PodSandbox, container *api.Cont
 	}
 }
 
-func (p *plugin) Synchronize(pods []*api.PodSandbox, containers []*api.Container) ([]*api.ContainerUpdate, error) {
+func (p *plugin) Synchronize(_ context.Context, pods []*api.PodSandbox, containers []*api.Container) ([]*api.ContainerUpdate, error) {
 	if cfg.VerboseLevel > 2 {
 		p.dump("Synchronize", "pods", pods, "containers", containers)
 	}
@@ -185,26 +185,26 @@ func (p *plugin) Synchronize(pods []*api.PodSandbox, containers []*api.Container
 	return nil, nil
 }
 
-func (p *plugin) Shutdown() {
+func (p *plugin) Shutdown(_ context.Context) {
 	p.dump("Shutdown")
 }
 
-func (p *plugin) RunPodSandbox(pod *api.PodSandbox) error {
+func (p *plugin) RunPodSandbox(_ context.Context, pod *api.PodSandbox) error {
 	p.differ("RunPodSandbox", pod, nil)
 	return nil
 }
 
-func (p *plugin) StopPodSandbox(pod *api.PodSandbox) error {
+func (p *plugin) StopPodSandbox(_ context.Context, pod *api.PodSandbox) error {
 	p.differ("StopPodSandbox", pod, nil)
 	return nil
 }
 
-func (p *plugin) RemovePodSandbox(pod *api.PodSandbox) error {
+func (p *plugin) RemovePodSandbox(_ context.Context, pod *api.PodSandbox) error {
 	p.differ("RemovePodSandbox", pod, nil)
 	return nil
 }
 
-func (p *plugin) CreateContainer(pod *api.PodSandbox, container *api.Container) (*api.ContainerAdjustment, []*api.ContainerUpdate, error) {
+func (p *plugin) CreateContainer(_ context.Context, pod *api.PodSandbox, container *api.Container) (*api.ContainerAdjustment, []*api.ContainerUpdate, error) {
 	p.differ("CreateContainer", pod, container)
 
 	adjust := &api.ContainerAdjustment{}
@@ -212,39 +212,39 @@ func (p *plugin) CreateContainer(pod *api.PodSandbox, container *api.Container) 
 	return adjust, nil, nil
 }
 
-func (p *plugin) PostCreateContainer(pod *api.PodSandbox, container *api.Container) error {
+func (p *plugin) PostCreateContainer(_ context.Context, pod *api.PodSandbox, container *api.Container) error {
 	p.differ("PostCreateContainer", pod, container)
 	return nil
 }
 
-func (p *plugin) StartContainer(pod *api.PodSandbox, container *api.Container) error {
+func (p *plugin) StartContainer(_ context.Context, pod *api.PodSandbox, container *api.Container) error {
 	p.differ("StartContainer", pod, container)
 	return nil
 }
 
-func (p *plugin) PostStartContainer(pod *api.PodSandbox, container *api.Container) error {
+func (p *plugin) PostStartContainer(_ context.Context, pod *api.PodSandbox, container *api.Container) error {
 	p.differ("PostStartContainer", pod, container)
 	return nil
 }
 
-func (p *plugin) UpdateContainer(pod *api.PodSandbox, container *api.Container) ([]*api.ContainerUpdate, error) {
+func (p *plugin) UpdateContainer(_ context.Context, pod *api.PodSandbox, container *api.Container) ([]*api.ContainerUpdate, error) {
 	p.differ("UpdateContainer", pod, container)
 
 	return nil, nil
 }
 
-func (p *plugin) PostUpdateContainer(pod *api.PodSandbox, container *api.Container) error {
+func (p *plugin) PostUpdateContainer(_ context.Context, pod *api.PodSandbox, container *api.Container) error {
 	p.differ("PostUpdateContainer", pod, container)
 	return nil
 }
 
-func (p *plugin) StopContainer(pod *api.PodSandbox, container *api.Container) ([]*api.ContainerUpdate, error) {
+func (p *plugin) StopContainer(_ context.Context, pod *api.PodSandbox, container *api.Container) ([]*api.ContainerUpdate, error) {
 	p.differ("StopContainer", pod, container)
 
 	return nil, nil
 }
 
-func (p *plugin) RemoveContainer(pod *api.PodSandbox, container *api.Container) error {
+func (p *plugin) RemoveContainer(_ context.Context, pod *api.PodSandbox, container *api.Container) error {
 	p.differ("RemoveContainer", pod, container)
 	return nil
 }

--- a/plugins/hook-injector/hook-injector.go
+++ b/plugins/hook-injector/hook-injector.go
@@ -43,7 +43,7 @@ type plugin struct {
 	mgr  *hooks.Manager
 }
 
-func (p *plugin) CreateContainer(pod *api.PodSandbox, container *api.Container) (*api.ContainerAdjustment, []*api.ContainerUpdate, error) {
+func (p *plugin) CreateContainer(_ context.Context, pod *api.PodSandbox, container *api.Container) (*api.ContainerAdjustment, []*api.ContainerUpdate, error) {
 	ctrName := containerName(pod, container)
 
 	if verbose {

--- a/plugins/logger/nri-logger.go
+++ b/plugins/logger/nri-logger.go
@@ -141,8 +141,8 @@ func (p *plugin) PostStartContainer(_ context.Context, pod *api.PodSandbox, cont
 	return nil
 }
 
-func (p *plugin) UpdateContainer(_ context.Context, pod *api.PodSandbox, container *api.Container) ([]*api.ContainerUpdate, error) {
-	dump("UpdateContainer", "pod", pod, "container", container)
+func (p *plugin) UpdateContainer(_ context.Context, pod *api.PodSandbox, container *api.Container, r *api.LinuxResources) ([]*api.ContainerUpdate, error) {
+	dump("UpdateContainer", "pod", pod, "container", container, "resources", r)
 	return nil, nil
 }
 

--- a/plugins/logger/nri-logger.go
+++ b/plugins/logger/nri-logger.go
@@ -50,7 +50,7 @@ var (
 	_   = stub.ConfigureInterface(&plugin{})
 )
 
-func (p *plugin) Configure(config, runtime, version string) (stub.EventMask, error) {
+func (p *plugin) Configure(_ context.Context, config, runtime, version string) (stub.EventMask, error) {
 	log.Infof("got configuration data: %q from runtime %s %s", config, runtime, version)
 	if config == "" {
 		return p.mask, nil
@@ -79,7 +79,7 @@ func (p *plugin) Configure(config, runtime, version string) (stub.EventMask, err
 	return p.mask, nil
 }
 
-func (p *plugin) Synchronize(pods []*api.PodSandbox, containers []*api.Container) ([]*api.ContainerUpdate, error) {
+func (p *plugin) Synchronize(_ context.Context, pods []*api.PodSandbox, containers []*api.Container) ([]*api.ContainerUpdate, error) {
 	dump("Synchronize", "pods", pods, "containers", containers)
 	return nil, nil
 }
@@ -88,22 +88,22 @@ func (p *plugin) Shutdown() {
 	dump("Shutdown")
 }
 
-func (p *plugin) RunPodSandbox(pod *api.PodSandbox) error {
+func (p *plugin) RunPodSandbox(_ context.Context, pod *api.PodSandbox) error {
 	dump("RunPodSandbox", "pod", pod)
 	return nil
 }
 
-func (p *plugin) StopPodSandbox(pod *api.PodSandbox) error {
+func (p *plugin) StopPodSandbox(_ context.Context, pod *api.PodSandbox) error {
 	dump("StopPodSandbox", "pod", pod)
 	return nil
 }
 
-func (p *plugin) RemovePodSandbox(pod *api.PodSandbox) error {
+func (p *plugin) RemovePodSandbox(_ context.Context, pod *api.PodSandbox) error {
 	dump("RemovePodSandbox", "pod", pod)
 	return nil
 }
 
-func (p *plugin) CreateContainer(pod *api.PodSandbox, container *api.Container) (*api.ContainerAdjustment, []*api.ContainerUpdate, error) {
+func (p *plugin) CreateContainer(_ context.Context, pod *api.PodSandbox, container *api.Container) (*api.ContainerAdjustment, []*api.ContainerUpdate, error) {
 	dump("CreateContainer", "pod", pod, "container", container)
 
 	adjust := &api.ContainerAdjustment{}
@@ -126,37 +126,37 @@ func (p *plugin) CreateContainer(pod *api.PodSandbox, container *api.Container) 
 	return adjust, nil, nil
 }
 
-func (p *plugin) PostCreateContainer(pod *api.PodSandbox, container *api.Container) error {
+func (p *plugin) PostCreateContainer(_ context.Context, pod *api.PodSandbox, container *api.Container) error {
 	dump("PostCreateContainer", "pod", pod, "container", container)
 	return nil
 }
 
-func (p *plugin) StartContainer(pod *api.PodSandbox, container *api.Container) error {
+func (p *plugin) StartContainer(_ context.Context, pod *api.PodSandbox, container *api.Container) error {
 	dump("StartContainer", "pod", pod, "container", container)
 	return nil
 }
 
-func (p *plugin) PostStartContainer(pod *api.PodSandbox, container *api.Container) error {
+func (p *plugin) PostStartContainer(_ context.Context, pod *api.PodSandbox, container *api.Container) error {
 	dump("PostStartContainer", "pod", pod, "container", container)
 	return nil
 }
 
-func (p *plugin) UpdateContainer(pod *api.PodSandbox, container *api.Container) ([]*api.ContainerUpdate, error) {
+func (p *plugin) UpdateContainer(_ context.Context, pod *api.PodSandbox, container *api.Container) ([]*api.ContainerUpdate, error) {
 	dump("UpdateContainer", "pod", pod, "container", container)
 	return nil, nil
 }
 
-func (p *plugin) PostUpdateContainer(pod *api.PodSandbox, container *api.Container) error {
+func (p *plugin) PostUpdateContainer(_ context.Context, pod *api.PodSandbox, container *api.Container) error {
 	dump("PostUpdateContainer", "pod", pod, "container", container)
 	return nil
 }
 
-func (p *plugin) StopContainer(pod *api.PodSandbox, container *api.Container) ([]*api.ContainerUpdate, error) {
+func (p *plugin) StopContainer(_ context.Context, pod *api.PodSandbox, container *api.Container) ([]*api.ContainerUpdate, error) {
 	dump("StopContainer", "pod", pod, "container", container)
 	return nil, nil
 }
 
-func (p *plugin) RemoveContainer(pod *api.PodSandbox, container *api.Container) error {
+func (p *plugin) RemoveContainer(_ context.Context, pod *api.PodSandbox, container *api.Container) error {
 	dump("RemoveContainer", "pod", pod, "container", container)
 	return nil
 }

--- a/plugins/template/plugin.go
+++ b/plugins/template/plugin.go
@@ -120,7 +120,7 @@ func (p *plugin) PostStartContainer(_ context.Context, pod *api.PodSandbox, ctr 
 	return nil
 }
 
-func (p *plugin) UpdateContainer(_ context.Context, pod *api.PodSandbox, ctr *api.Container) ([]*api.ContainerUpdate, error) {
+func (p *plugin) UpdateContainer(_ context.Context, pod *api.PodSandbox, ctr *api.Container, r *api.LinuxResources) ([]*api.ContainerUpdate, error) {
 	log.Infof("Updating container %s/%s/%s...", pod.GetNamespace(), pod.GetName(), ctr.GetName())
 
 	//

--- a/plugins/template/plugin.go
+++ b/plugins/template/plugin.go
@@ -43,7 +43,7 @@ var (
 	log *logrus.Logger
 )
 
-func (p *plugin) Configure(config, runtime, version string) (stub.EventMask, error) {
+func (p *plugin) Configure(_ context.Context, config, runtime, version string) (stub.EventMask, error) {
 	log.Infof("Connected to %s/%s...", runtime, version)
 
 	if config == "" {
@@ -60,31 +60,31 @@ func (p *plugin) Configure(config, runtime, version string) (stub.EventMask, err
 	return 0, nil
 }
 
-func (p *plugin) Synchronize(pods []*api.PodSandbox, containers []*api.Container) ([]*api.ContainerUpdate, error) {
+func (p *plugin) Synchronize(_ context.Context, pods []*api.PodSandbox, containers []*api.Container) ([]*api.ContainerUpdate, error) {
 	log.Info("Synchronizing state with the runtime...")
 	return nil, nil
 }
 
-func (p *plugin) Shutdown() {
+func (p *plugin) Shutdown(_ context.Context) {
 	log.Info("Runtime shutting down...")
 }
 
-func (p *plugin) RunPodSandbox(pod *api.PodSandbox) error {
+func (p *plugin) RunPodSandbox(_ context.Context, pod *api.PodSandbox) error {
 	log.Infof("Started pod %s/%s...", pod.GetNamespace(), pod.GetName())
 	return nil
 }
 
-func (p *plugin) StopPodSandbox(pod *api.PodSandbox) error {
+func (p *plugin) StopPodSandbox(_ context.Context, pod *api.PodSandbox) error {
 	log.Infof("Stopped pod %s/%s...", pod.GetNamespace(), pod.GetName())
 	return nil
 }
 
-func (p *plugin) RemovePodSandbox(pod *api.PodSandbox) error {
+func (p *plugin) RemovePodSandbox(_ context.Context, pod *api.PodSandbox) error {
 	log.Infof("Removed pod %s/%s...", pod.GetNamespace(), pod.GetName())
 	return nil
 }
 
-func (p *plugin) CreateContainer(pod *api.PodSandbox, ctr *api.Container) (*api.ContainerAdjustment, []*api.ContainerUpdate, error) {
+func (p *plugin) CreateContainer(_ context.Context, pod *api.PodSandbox, ctr *api.Container) (*api.ContainerAdjustment, []*api.ContainerUpdate, error) {
 	log.Infof("Creating container %s/%s/%s...", pod.GetNamespace(), pod.GetName(), ctr.GetName())
 
 	//
@@ -105,22 +105,22 @@ func (p *plugin) CreateContainer(pod *api.PodSandbox, ctr *api.Container) (*api.
 	return adjustment, updates, nil
 }
 
-func (p *plugin) PostCreateContainer(pod *api.PodSandbox, ctr *api.Container) error {
+func (p *plugin) PostCreateContainer(_ context.Context, pod *api.PodSandbox, ctr *api.Container) error {
 	log.Infof("Created container %s/%s/%s...", pod.GetNamespace(), pod.GetName(), ctr.GetName())
 	return nil
 }
 
-func (p *plugin) StartContainer(pod *api.PodSandbox, ctr *api.Container) error {
+func (p *plugin) StartContainer(_ context.Context, pod *api.PodSandbox, ctr *api.Container) error {
 	log.Infof("Starting container %s/%s/%s...", pod.GetNamespace(), pod.GetName(), ctr.GetName())
 	return nil
 }
 
-func (p *plugin) PostStartContainer(pod *api.PodSandbox, ctr *api.Container) error {
+func (p *plugin) PostStartContainer(_ context.Context, pod *api.PodSandbox, ctr *api.Container) error {
 	log.Infof("Started container %s/%s/%s...", pod.GetNamespace(), pod.GetName(), ctr.GetName())
 	return nil
 }
 
-func (p *plugin) UpdateContainer(pod *api.PodSandbox, ctr *api.Container) ([]*api.ContainerUpdate, error) {
+func (p *plugin) UpdateContainer(_ context.Context, pod *api.PodSandbox, ctr *api.Container) ([]*api.ContainerUpdate, error) {
 	log.Infof("Updating container %s/%s/%s...", pod.GetNamespace(), pod.GetName(), ctr.GetName())
 
 	//
@@ -137,12 +137,12 @@ func (p *plugin) UpdateContainer(pod *api.PodSandbox, ctr *api.Container) ([]*ap
 	return updates, nil
 }
 
-func (p *plugin) PostUpdateContainer(pod *api.PodSandbox, ctr *api.Container) error {
+func (p *plugin) PostUpdateContainer(_ context.Context, pod *api.PodSandbox, ctr *api.Container) error {
 	log.Infof("Updated container %s/%s/%s...", pod.GetNamespace(), pod.GetName(), ctr.GetName())
 	return nil
 }
 
-func (p *plugin) StopContainer(pod *api.PodSandbox, ctr *api.Container) ([]*api.ContainerUpdate, error) {
+func (p *plugin) StopContainer(_ context.Context, pod *api.PodSandbox, ctr *api.Container) ([]*api.ContainerUpdate, error) {
 	log.Infof("Stopped container %s/%s/%s...", pod.GetNamespace(), pod.GetName(), ctr.GetName())
 
 	//
@@ -154,7 +154,7 @@ func (p *plugin) StopContainer(pod *api.PodSandbox, ctr *api.Container) ([]*api.
 	return []*api.ContainerUpdate{}, nil
 }
 
-func (p *plugin) RemoveContainer(pod *api.PodSandbox, ctr *api.Container) error {
+func (p *plugin) RemoveContainer(_ context.Context, pod *api.PodSandbox, ctr *api.Container) error {
 	log.Infof("Removed container %s/%s/%s...", pod.GetNamespace(), pod.GetName(), ctr.GetName())
 	return nil
 }

--- a/plugins/v010-adapter/v010-adapter.go
+++ b/plugins/v010-adapter/v010-adapter.go
@@ -38,16 +38,16 @@ var (
 	log *logrus.Logger
 )
 
-func (p *plugin) Configure(config, runtime, version string) (stub.EventMask, error) {
+func (p *plugin) Configure(_ context.Context, config, runtime, version string) (stub.EventMask, error) {
 	log.Infof("Connected to %s/%s...", runtime, version)
 	return 0, nil
 }
 
-func (p *plugin) Shutdown() {
+func (p *plugin) Shutdown(_ context.Context) {
 	log.Info("Runtime shutting down...")
 }
 
-func (p *plugin) RunPodSandbox(pod *api.PodSandbox) error {
+func (p *plugin) RunPodSandbox(_ context.Context, pod *api.PodSandbox) error {
 	log.Infof("Started pod %s/%s...", pod.GetNamespace(), pod.GetName())
 
 	nric, err := nri.New()
@@ -72,7 +72,7 @@ func (p *plugin) RunPodSandbox(pod *api.PodSandbox) error {
 	return nil
 }
 
-func (p *plugin) StopPodSandbox(pod *api.PodSandbox) error {
+func (p *plugin) StopPodSandbox(_ context.Context, pod *api.PodSandbox) error {
 	log.Infof("Stopped pod %s/%s...", pod.GetNamespace(), pod.GetName())
 
 	nric, err := nri.New()
@@ -97,7 +97,7 @@ func (p *plugin) StopPodSandbox(pod *api.PodSandbox) error {
 	return nil
 }
 
-func (p *plugin) StartContainer(pod *api.PodSandbox, ctr *api.Container) error {
+func (p *plugin) StartContainer(_ context.Context, pod *api.PodSandbox, ctr *api.Container) error {
 	log.Infof("Starting container %s/%s/%s...", pod.GetNamespace(), pod.GetName(), ctr.GetName())
 
 	nric, err := nri.New()
@@ -122,7 +122,7 @@ func (p *plugin) StartContainer(pod *api.PodSandbox, ctr *api.Container) error {
 	return nil
 }
 
-func (p *plugin) StopContainer(pod *api.PodSandbox, ctr *api.Container) ([]*api.ContainerUpdate, error) {
+func (p *plugin) StopContainer(_ context.Context, pod *api.PodSandbox, ctr *api.Container) ([]*api.ContainerUpdate, error) {
 	log.Infof("Stopped container %s/%s/%s...", pod.GetNamespace(), pod.GetName(), ctr.GetName())
 
 	nric, err := nri.New()


### PR DESCRIPTION
Don't hide the ttRPC request context from plugins. Pass the context on to the plugin's request handler. Once we have opentelemetry ttRPC instrumentation support, this should allow us to properly propagate trace spans and have detailed instrumentation on the plugins side properly nested into the related original request on the runtime side.

While making API-breaking changes, also fix UpdateContainer adding an argument with the updated resources.

Update sample plugins and tests with the updated interfaces and add basic tests for UpdateContainer which we lacked so far.