### PR TITLE
fix the `NRI_PLUGIN_NAME` env value when launching a pre-installed plugin

### DIFF
--- a/pkg/adaptation/plugin.go
+++ b/pkg/adaptation/plugin.go
@@ -119,7 +119,7 @@ func (r *Adaptation) newLaunchedPlugin(dir, idx, base, cfg string) (p *plugin, r
 	cmd := exec.Command(filepath.Join(dir, name))
 	cmd.ExtraFiles = []*os.File{peerFile}
 	cmd.Env = []string{
-		api.PluginNameEnvVar + "=" + name,
+		api.PluginNameEnvVar + "=" + base,
 		api.PluginIdxEnvVar + "=" + idx,
 		api.PluginSocketEnvVar + "=3",
 	}

--- a/pkg/stub/stub.go
+++ b/pkg/stub/stub.go
@@ -290,7 +290,7 @@ func New(p interface{}, opts ...Option) (Stub, error) {
 		return nil, err
 	}
 
-	if err := stub.getIdentity(); err != nil {
+	if err := stub.ensureIdentity(); err != nil {
 		return nil, err
 	}
 
@@ -678,8 +678,8 @@ func (stub *stub) StateChange(ctx context.Context, evt *api.StateChangeEvent) (*
 	return &api.StateChangeResponse{}, err
 }
 
-// getIdentity gets plugin index and name from the binary if those are unset.
-func (stub *stub) getIdentity() error {
+// ensureIdentity sets plugin index and name from the binary if those are unset.
+func (stub *stub) ensureIdentity() error {
 	if stub.idx != "" && stub.name != "" {
 		return nil
 	}


### PR DESCRIPTION
The environment variable `NRI_PLUGIN_NAME` actually represents name in the plugin
https://github.com/containerd/nri/blob/83295992ed466e5589a1a83ba3ad2bd6b6feb199/pkg/stub/stub.go#L273-L280
https://github.com/containerd/nri/blob/83295992ed466e5589a1a83ba3ad2bd6b6feb199/pkg/stub/stub.go#L450-L452

so if we pass `plugin name`(`< idx >-< base name >`), the log will print out 'plugin name' with duplicate `idx`.
```
time="2023-05-18T13:39:43+08:00" level=info msg="Subscribing plugin 03-03-logger (03-logger) for events RunPodSandbox,StopPodSandbox,RemovePodSandbox,CreateContainer,PostCreateContainer,StartContainer,PostStartContainer,UpdateContainer,PostUpdateContainer,StopContainer,RemoveContainer"
time="2023-05-18T13:39:43+08:00" level=info msg="Started plugin 03-03-logger..."
```

Note that there are some differences between the `plugin name` variable/field in plugin and adaptation.
|adaptation|plugin|
|---|---|
|base name|`stub.name`
|idx|`stub.idx`
|plugin name(idx + "-" name) |`stub.Name()` -> `stub.idx` + "-" + `stub.name`