### PR TITLE
.github: add test build to CI workflow.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,30 @@ jobs:
         with:
           working-directory: src/github.com/containerd/nri
 
+  test-build:
+    name: Check buildability
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: src/github.com/containerd/nri
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.20.x
+
+      - name: Set env
+        shell: bash
+        run: |
+          echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
+          echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+
+      - run: |
+          make all
+        working-directory: src/github.com/containerd/nri
+
   linters:
     name: Linters
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Add a job to do a simple test build as part of the CI workflow. This should make sure that PRs don't break building any of the sample plugins.