### PR TITLE
Fix deadlock during NRI plugin registration

### DIFF
--- a/pkg/adaptation/adaptation.go
+++ b/pkg/adaptation/adaptation.go
@@ -431,17 +431,15 @@ func (r *Adaptation) acceptPluginConnections(l net.Listener) error {
 				continue
 			}
 
-			r.Lock()
-
 			err = r.syncFn(ctx, p.synchronize)
 			if err != nil {
 				log.Infof(ctx, "failed to synchronize plugin: %v", err)
 			} else {
+				r.Lock()
 				r.plugins = append(r.plugins, p)
 				r.sortPlugins()
+				r.Unlock()
 			}
-
-			r.Unlock()
 
 			log.Infof(ctx, "plugin %q connected", p.name())
 		}


### PR DESCRIPTION
During NRI external plugin registration:

* acceptPluginConnections() is called
* adaptation lock from `nri/pkg/adaptation` is acquired
* `syncFn` is invoked
* `syncFn` acquires NRI lock in `pkg/nri/nri.go`

During container lifecycle events such as `ContainerStart`
* NRI lock is acquired in pkg/nri.go
* adaptation lock is acquired in `StateChange()` in `nri/pkg/adaptation`

As a result, the locking order during NRI plugin registration is:
* adaptation lock -> NRI lock

While the locking order during container starts is:
* NRI lock -> adaptation lock

Due the fact that the locking order is inverted and not consistent, it it possible to encounter a deadlock.

To fix the issue, during NRI plugin registration, first acquire the NRI lock (done via `syncFn` call) and only after acquire the adaptation lock. This ensures that NRI plugin registration the locking order is adaption lock -> NRI lock, which is consistent with the locking order during container lifecycle events.

Fixes https://github.com/containerd/containerd/issues/10085