### PR TITLE
stop closed plugins that will be removed

### DIFF
--- a/pkg/adaptation/adaptation.go
+++ b/pkg/adaptation/adaptation.go
@@ -369,11 +369,21 @@ func (r *Adaptation) stopPlugins() {
 }
 
 func (r *Adaptation) removeClosedPlugins() {
-	active := []*plugin{}
+	var active, closed []*plugin
 	for _, p := range r.plugins {
-		if !p.isClosed() {
+		if p.isClosed() {
+			closed = append(closed, p)
+		} else {
 			active = append(active, p)
 		}
+	}
+
+	if len(closed) != 0 {
+		go func() {
+			for _, plugin := range closed {
+				plugin.stop()
+			}
+		}()
 	}
 	r.plugins = active
 }


### PR DESCRIPTION
Most of Adaptation's methods call removeClosedPlugins to remove closed plugins, which are moved out of the r.plugins list and never operated on again.

It may remain a zombie process on the system, and using some tools it will look like the plugin is running normally.
```console
# pstree
...
        ├─containerd─┬─03-logger
        │            └─15*[{containerd}]
```

This pr causes `removeClosedPlugins` to call `plugin.stop` when removing closed plugins, which avoids these zombie processes.