### PR TITLE
adaptation: close plugin if initial synchronization fails.

### DIFF
--- a/pkg/adaptation/adaptation.go
+++ b/pkg/adaptation/adaptation.go
@@ -450,7 +450,7 @@ func (r *Adaptation) acceptPluginConnections(l net.Listener) error {
 				r.sortPlugins()
 				r.Unlock()
 
-				log.Infof(ctx, "plugin %q connected", p.name())
+				log.Infof(ctx, "plugin %q connected and synchronized", p.name())
 			}
 		}
 	}()

--- a/pkg/adaptation/adaptation.go
+++ b/pkg/adaptation/adaptation.go
@@ -449,9 +449,9 @@ func (r *Adaptation) acceptPluginConnections(l net.Listener) error {
 				r.plugins = append(r.plugins, p)
 				r.sortPlugins()
 				r.Unlock()
-			}
 
-			log.Infof(ctx, "plugin %q connected", p.name())
+				log.Infof(ctx, "plugin %q connected", p.name())
+			}
 		}
 	}()
 

--- a/pkg/adaptation/plugin.go
+++ b/pkg/adaptation/plugin.go
@@ -418,6 +418,7 @@ func (p *plugin) synchronize(ctx context.Context, pods []*PodSandbox, containers
 	}
 	rpl, err := p.stub.Synchronize(ctx, req)
 	if err != nil {
+		p.close()
 		return nil, err
 	}
 


### PR DESCRIPTION
Close the connection to the plugin if initial synchronization fails, like we do for all other failures considered unrecoverable.