### PR TITLE
Makefile: regenerate protobufs only on proto content change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,8 +171,14 @@ golangci-lint:
 #
 
 %.pb.go: %.proto
-	$(Q)echo "Generating $@..."; \
-	$(PROTO_COMPILE) $<
+	$(Q)chksum=$$(md5sum $< | awk '{print $$1}'); \
+	if grep -sq "source: $< $$chksum" $@; then \
+		echo "Up-to-date: $@"; \
+	else \
+		echo "Generating $@..."; \
+		$(PROTO_COMPILE) $< && \
+		sed -e "s|source: $<|source: $< $$chksum|" -i $@; \
+	fi
 
 #
 # targets for installing dependencies


### PR DESCRIPTION
make sometimes triggers generating protobufs in github actions due to proto/protobuf timestamp changes. This causes errors in github ci as protobuf files are not ment to be build there and thus tools are missing.

This change changes protobuf generation to happen only if proto file contents have changed after previous generation.