### PR TITLE
 generate: do not set OOMScoreAdj if no adjustment

### DIFF
--- a/pkg/runtime-tools/generate/generate.go
+++ b/pkg/runtime-tools/generate/generate.go
@@ -329,9 +329,6 @@ func (g *Generator) AdjustCgroupsPath(path string) {
 func (g *Generator) AdjustOomScoreAdj(score *nri.OptionalInt) {
 	if score != nil {
 		g.SetProcessOOMScoreAdj(int(score.Value))
-	} else {
-		g.SetProcessOOMScoreAdj(0)
-		g.Config.Process.OOMScoreAdj = nil
 	}
 }
 

--- a/pkg/runtime-tools/generate/generate_suite_test.go
+++ b/pkg/runtime-tools/generate/generate_suite_test.go
@@ -158,6 +158,26 @@ var _ = Describe("Adjustment", func() {
 		})
 	})
 
+	When("existing oom score adj", func() {
+		It("does not adjust Spec", func() {
+			var (
+				spec         = makeSpec()
+				expectedSpec = makeSpec()
+				adjust       = &api.ContainerAdjustment{}
+			)
+			oomScoreAdj := 123
+			spec.Process.OOMScoreAdj = &oomScoreAdj
+			expectedSpec.Process.OOMScoreAdj = &oomScoreAdj
+
+			rg := &rgen.Generator{Config: spec}
+			xg := xgen.SpecGenerator(rg)
+
+			Expect(xg).ToNot(BeNil())
+			Expect(xg.Adjust(adjust)).To(Succeed())
+			Expect(spec).To(Equal(expectedSpec))
+		})
+	})
+
 	When("has CPU shares", func() {
 		It("adjusts Spec correctly", func() {
 			var (


### PR DESCRIPTION
Existing OOMScoreAdj on the incoming spec should not be cleared.

Fixes https://github.com/containerd/nri/issues/117