### PR TITLE
adaptation: return nil as no-op adjustment.

### DIFF
--- a/pkg/adaptation/adaptation_suite_test.go
+++ b/pkg/adaptation/adaptation_suite_test.go
@@ -448,7 +448,19 @@ var _ = Describe("Plugin container creation adjustments", func() {
 	adjust := func(subject string, p *mockPlugin, _ *api.PodSandbox, c *api.Container, overwrite bool) (*api.ContainerAdjustment, []*api.ContainerUpdate, error) {
 		plugin := p.idx + "-" + p.name
 		a := &api.ContainerAdjustment{}
+		if plugin == "00-all-nil-adjust" {
+			return nil, nil, nil
+		}
 		switch subject {
+		case "all-nil-adjustment":
+			return nil, nil, nil
+
+		case "00-nil-adjustment", "10-nil-adjustment":
+			if subject[:2] == p.idx {
+				return nil, nil, nil
+			}
+			a.AddAnnotation("non-nil-adjustment", p.idx+"-"+p.name)
+
 		case "annotation":
 			if overwrite {
 				a.RemoveAnnotation("key")
@@ -619,14 +631,19 @@ var _ = Describe("Plugin container creation adjustments", func() {
 
 	When("there is a single plugin", func() {
 		BeforeEach(func() {
-			s.Prepare(&mockRuntime{}, &mockPlugin{idx: "00", name: "test"})
+
+			s.Prepare(
+				&mockRuntime{},
+				&mockPlugin{idx: "00", name: "all-nil-adjust"},
+				&mockPlugin{idx: "00", name: "test"},
+			)
 		})
 
 		DescribeTable("should be successfully collected without conflicts",
 			func(subject string, expected *api.ContainerAdjustment) {
 				var (
 					runtime = s.runtime
-					plugin  = s.plugins[0]
+					plugins = s.plugins
 					ctx     = context.Background()
 
 					pod = &api.PodSandbox{
@@ -679,7 +696,8 @@ var _ = Describe("Plugin container creation adjustments", func() {
 					return adjust(subject, p, pod, ctr, false)
 				}
 
-				plugin.createContainer = create
+				plugins[0].createContainer = create
+				plugins[1].createContainer = create
 
 				s.Startup()
 
@@ -694,6 +712,10 @@ var _ = Describe("Plugin container creation adjustments", func() {
 				Expect(protoEqual(reply.Adjust.Strip(), expected.Strip())).Should(BeTrue(),
 					protoDiff(reply.Adjust, expected))
 			},
+
+			Entry("nil adjustment", "all-nil-adjustment",
+				nil,
+			),
 
 			Entry("adjust annotations", "annotation",
 				&api.ContainerAdjustment{
@@ -955,6 +977,7 @@ var _ = Describe("Plugin container creation adjustments", func() {
 		BeforeEach(func() {
 			s.Prepare(
 				&mockRuntime{},
+				&mockPlugin{idx: "00", name: "all-nil-adjust"},
 				&mockPlugin{idx: "10", name: "foo"},
 				&mockPlugin{idx: "00", name: "bar"},
 			)
@@ -1007,11 +1030,12 @@ var _ = Describe("Plugin container creation adjustments", func() {
 				)
 
 				create := func(p *mockPlugin, pod *api.PodSandbox, ctr *api.Container) (*api.ContainerAdjustment, []*api.ContainerUpdate, error) {
-					return adjust(subject, p, pod, ctr, p == plugins[0] && remove)
+					return adjust(subject, p, pod, ctr, p == plugins[1] && remove)
 				}
 
 				plugins[0].createContainer = create
 				plugins[1].createContainer = create
+				plugins[2].createContainer = create
 
 				s.Startup()
 
@@ -1030,6 +1054,25 @@ var _ = Describe("Plugin container creation adjustments", func() {
 						protoDiff(reply.Adjust, expected))
 				}
 			},
+
+			Entry("all nil adjustment", "all-nil-adjustment", false, false,
+				nil,
+			),
+
+			Entry("00 nil adjustment", "00-nil-adjustment", false, false,
+				&api.ContainerAdjustment{
+					Annotations: map[string]string{
+						"non-nil-adjustment": "10-foo",
+					},
+				},
+			),
+			Entry("10 nil adjustment", "10-nil-adjustment", false, false,
+				&api.ContainerAdjustment{
+					Annotations: map[string]string{
+						"non-nil-adjustment": "00-bar",
+					},
+				},
+			),
 
 			Entry("adjust annotations (conflicts)", "annotation", false, true, nil),
 			Entry("adjust annotations", "annotation", true, false,
@@ -1232,6 +1275,7 @@ var _ = Describe("Plugin container creation adjustments", func() {
 						),
 					},
 				},
+				&mockPlugin{idx: "00", name: "all-nil-adjust"},
 				&mockPlugin{idx: "00", name: "foo"},
 				&mockPlugin{idx: "10", name: "validator1"},
 				&mockPlugin{idx: "20", name: "validator2"},


### PR DESCRIPTION
With no NRI plugins registered or none of the registered plugins requesting changes to a container, we should ideally skip applying NRI adjustments on the runtime side altogether, instead of going through the motions without any effective changes. Having seen #117 (quickly fixed by #116), this is not the case.

This PR is the first part in an attempt to change that. With this PR in place, we don't create an a priori empty adjustment in preparation to process NRI requests. We only create it once a plugin makes an actual change to the container being created. Effectively, this should result in a nil adjustment reply when there are no plugins present, or none of the present plugins touches a container.

The other part is a related change to the [runtime integration code](https://github.com/klihub/containerd/commit/276cb1c6d433083e8bc1312cb2ec14f77cb6c657) to check for this and short-circuit processing.