### PR TITLE
Bump up golang to 1.22.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
 
       - name: Set env
         shell: bash
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
 
       # needed for wasm plugins
       - uses: acifani/setup-tinygo@v2
@@ -78,7 +78,7 @@ jobs:
 
     strategy:
       matrix:
-        go: [1.22.3]
+        go: [1.22.x, 1.23.x]
         os: [ubuntu-22.04]
 
     steps:
@@ -103,7 +103,7 @@ jobs:
 
     strategy:
       matrix:
-        go: [1.21.x, 1.22.3]
+        go: [1.22.x, 1.23.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,10 @@ build-plugins: $(PLUGINS)
 build-check:
 	$(Q)$(GO_BUILD) -v $(GO_MODULES)
 
+mod-tidy:
+	$(Q)$(GO_CMD) mod tidy
+	$(Q)./scripts/go-mod-tidy
+
 #
 # clean targets
 #

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,12 +1,12 @@
 module github.com/containerd/nri/examples
 
-go 1.18
+go 1.22.0
 
 require (
 	github.com/containerd/cgroups v1.0.3
 	github.com/containerd/nri v0.1.0
 	github.com/opencontainers/runtime-spec v1.0.3-0.20220825212826-86290f6a00fb
-	github.com/sirupsen/logrus v1.8.1
+	github.com/sirupsen/logrus v1.9.3
 )
 
 require (
@@ -14,7 +14,7 @@ require (
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/godbus/dbus/v5 v5.0.4 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	golang.org/x/sys v0.13.0 // indirect
+	golang.org/x/sys v0.21.0 // indirect
 )
 
 replace github.com/containerd/nri => ../

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -30,12 +30,14 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
-github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -66,8 +68,9 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
-golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
+golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
@@ -86,3 +89,4 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/nri
 
-go 1.21
+go 1.22.0
 
 require (
 	github.com/containerd/ttrpc v1.2.6-0.20240827082320-b5cd6e4b3287

--- a/plugins/device-injector/go.mod
+++ b/plugins/device-injector/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/nri/plugins/device-injector
 
-go 1.21
+go 1.22.0
 
 require (
 	github.com/containerd/nri v0.6.1

--- a/plugins/differ/go.mod
+++ b/plugins/differ/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/nri/plugins/differ
 
-go 1.21
+go 1.22.0
 
 require (
 	github.com/containerd/nri v0.6.1

--- a/plugins/hook-injector/go.mod
+++ b/plugins/hook-injector/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/nri/plugins/hook-injector
 
-go 1.21
+go 1.22.0
 
 require (
 	github.com/containerd/nri v0.6.1

--- a/plugins/logger/go.mod
+++ b/plugins/logger/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/nri/plugins/logger
 
-go 1.21
+go 1.22.0
 
 require (
 	github.com/containerd/nri v0.6.1

--- a/plugins/network-logger/go.mod
+++ b/plugins/network-logger/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/nri/plugins/network-logger
 
-go 1.21
+go 1.22.0
 
 require (
 	github.com/containerd/nri v0.6.1

--- a/plugins/template/go.mod
+++ b/plugins/template/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/nri/plugins/template
 
-go 1.21
+go 1.22.0
 
 require (
 	github.com/containerd/nri v0.6.1

--- a/plugins/ulimit-adjuster/go.mod
+++ b/plugins/ulimit-adjuster/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/nri/plugins/ulimit-adjuster
 
-go 1.21
+go 1.22.0
 
 replace github.com/containerd/nri => ../..
 

--- a/plugins/v010-adapter/go.mod
+++ b/plugins/v010-adapter/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/nri/plugins/v010-adapter
 
-go 1.21
+go 1.22.0
 
 require (
 	github.com/containerd/containerd v1.6.9

--- a/plugins/wasm/go.mod
+++ b/plugins/wasm/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/nri/plugins/wasm
 
-go 1.21
+go 1.22.0
 
 require github.com/containerd/nri v0.6.1
 

--- a/scripts/go-mod-tidy
+++ b/scripts/go-mod-tidy
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+#
+# Run go mod tidy in all go modules
+#
+set -eu -o pipefail
+
+find . -name go.mod | while read -r gomod; do
+    dir=$(dirname "$gomod")
+    
+    pushd "$dir"
+    go mod tidy
+    popd
+done


### PR DESCRIPTION
Given golang 1.21 has been [EOL](https://go.dev/doc/devel/release#policy:~:text=Each%20major%20Go%20release%20is%20supported%20until%20there%20are%20two%20newer%20major%20releases.), I think we can upgrade golang to 1.22.0 at least? (containerd uses [1.22.0](https://github.com/containerd/containerd/blob/main/go.mod), cri-o uses [1.23](https://github.com/cri-o/cri-o/blob/main/go.mod) in main branch.