### PR TITLE
adaptation: honor context deadline in WASM runtime/plugins.

### DIFF
--- a/pkg/adaptation/adaptation.go
+++ b/pkg/adaptation/adaptation.go
@@ -30,6 +30,8 @@ import (
 	"github.com/containerd/nri/pkg/api"
 	"github.com/containerd/nri/pkg/log"
 	"github.com/containerd/ttrpc"
+	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 )
 
 const (
@@ -129,7 +131,21 @@ func New(name, version string, syncFn SyncFn, updateFn UpdateFn, opts ...Option)
 		return nil, fmt.Errorf("failed to create NRI adaptation, nil UpdateFn")
 	}
 
-	wasmPlugins, err := api.NewPluginPlugin(context.Background())
+	wasmWithCloseOnContextDone := func(ctx context.Context) (wazero.Runtime, error) {
+		var (
+			cfg = wazero.NewRuntimeConfig().WithCloseOnContextDone(true)
+			r   = wazero.NewRuntimeWithConfig(ctx, cfg)
+		)
+		if _, err := wasi_snapshot_preview1.Instantiate(ctx, r); err != nil {
+			return nil, err
+		}
+		return r, nil
+	}
+
+	wasmPlugins, err := api.NewPluginPlugin(
+		context.Background(),
+		api.WazeroRuntime(wasmWithCloseOnContextDone),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize WASM service: %w", err)
 	}

--- a/pkg/adaptation/plugin.go
+++ b/pkg/adaptation/plugin.go
@@ -336,6 +336,7 @@ func (p *plugin) start(name, version string) (err error) {
 // close a plugin shutting down its multiplexed ttrpc connections.
 func (p *plugin) close() {
 	if p.impl.isWasm() {
+		p.closed = true
 		return
 	}
 


### PR DESCRIPTION
Don't use the default wazero runtime configuration. Instead use one with `WithCloseOnContextDone(true) in order for calls to WASM plugins to properly obey context deadlines, which otherwise they don't. Also, once a WASM plugin is closed (for instance due to a request processing timeout), mark the plugin closed so it gets properly removed from the list of active plugins.

Fixes #138.
