### PR TITLE
.github: update project-checks, use local install-go action in CI workflow.

### DIFF
--- a/.github/actions/install-go/action.yml
+++ b/.github/actions/install-go/action.yml
@@ -1,0 +1,16 @@
+name: "Setup Go"
+description: "Reusable action to install Go, so there is one place to bump Go versions"
+inputs:
+  go-version:
+    required: true
+    default: "1.23.7"
+    description: "Go version to install"
+
+runs:
+  using: composite
+  steps:
+    - name: "Setup Go"
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ inputs.go-version }}
+        cache: false # see actions/setup-go#368

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,6 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/setup-go@v5
-        with:
-          go-version: 1.21.x
-
       - name: Set env
         shell: bash
         # TODO(thaJeztah): remove working-directory, path, and GOPATH once project-checks stops needing them; see https://github.com/containerd/nri/pull/53/commits/872fb0ce3dce136f3ae67c068ce78607565194ef#r1324366346
@@ -30,6 +26,8 @@ jobs:
           path: src/github.com/containerd/nri
           fetch-depth: 25
 
+      - uses: ./src/github.com/containerd/nri/.github/actions/install-go
+
       - uses: containerd/project-checks@v1
         with:
           working-directory: src/github.com/containerd/nri
@@ -41,9 +39,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version: 1.21.x
+      - uses: ./.github/actions/install-go
 
       # needed for wasm plugins
       - uses: acifani/setup-tinygo@v2
@@ -83,7 +79,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: ./.github/actions/install-go
         with:
           go-version: ${{ matrix.go }}
 
@@ -107,7 +103,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: ./.github/actions/install-go
         with:
           go-version: ${{ matrix.go }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: ./src/github.com/containerd/nri/.github/actions/install-go
 
-      - uses: containerd/project-checks@v1
+      - uses: containerd/project-checks@v1.2.2
         with:
           working-directory: src/github.com/containerd/nri
 
@@ -74,23 +74,23 @@ jobs:
 
     strategy:
       matrix:
-        go: [1.22.3]
+        go-version: ["1.23.7", "1.24.1"]
         os: [ubuntu-22.04]
 
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-go
         with:
-          go-version: ${{ matrix.go }}
+          go-version: ${{ matrix.go-version }}
 
       - name: Set env
         shell: bash
         run: |
           echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
-      - uses: golangci/golangci-lint-action@v3
+      - uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.58.0
+          version: v1.64.8
 
   tests:
     name: Tests
@@ -99,13 +99,13 @@ jobs:
 
     strategy:
       matrix:
-        go: [1.21.x, 1.22.3]
+        go-version: ["1.23.7", "1.24.1"]
 
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-go
         with:
-          go-version: ${{ matrix.go }}
+          go-version: ${{ matrix.go-version }}
 
       - name: Set env
         shell: bash


### PR DESCRIPTION
This patch series
- updates `project-checks` to use latest tagged version
- adopts local `install-go` action from containerd
- updates the CI workflow to use same golang versions for linting and tests as containerd 1.7
- updates `golangci-lint` version

These version bumps should fix failing project-checks in CI. 