### PR TITLE
plugins/logger: fix default event subscription mask.

### DIFF
--- a/plugins/logger/nri-logger.go
+++ b/plugins/logger/nri-logger.go
@@ -215,7 +215,7 @@ func main() {
 
 	flag.StringVar(&pluginName, "name", "", "plugin name to register to NRI")
 	flag.StringVar(&pluginIdx, "idx", "", "plugin index to register to NRI")
-	flag.StringVar(&events, "events", "all", "comma-separated list of events to subscribe for")
+	flag.StringVar(&events, "events", "", "comma-separated list of events to subscribe for")
 	flag.StringVar(&cfg.LogFile, "log-file", "", "logfile name, if logging to a file")
 	flag.StringVar(&cfg.AddAnnotation, "add-annotation", "", "add this annotation to containers")
 	flag.StringVar(&cfg.SetAnnotation, "set-annotation", "", "set this annotation on containers")
@@ -239,8 +239,10 @@ func main() {
 	}
 
 	p := &plugin{}
-	if p.mask, err = api.ParseEventMask(events); err != nil {
-		log.Fatalf("failed to parse events: %v", err)
+	if events != "" {
+		if p.mask, err = api.ParseEventMask(events); err != nil {
+			log.Fatalf("failed to parse events: %v", err)
+		}
 	}
 	cfg.Events = strings.Split(events, ",")
 


### PR DESCRIPTION
Let the stub determine which events the logger plugin subscribes to, to fix a recently introduced startup failure.

Ever since support for the new pod update events has been merged, unless the event subscription mask is overidden with the `--events` command line option, the sample logger plugin fails to start up with the following error message:

> plugin exited with error internal error: unhandled events UpdatePodSandbox,PostUpdatePodSandbox (0x1800)

This patch should fix that.