### PR TITLE
ci: update linter config and add dependabot settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      golang-x:
+        patterns:
+          - "golang.org/x/*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,7 @@ linters:
     - gofmt
     - goimports
     - ineffassign
-    - vet
+    - govet
     - unused
     - misspell
     - revive


### PR DESCRIPTION
- replace deprecated linter name "vet" with "govet" in .golangci.yml
- add dependabot configuration to automatically update:
  - go modules (weekly)
  - gitHub actions (weekly)