### PR TITLE
Include linux device cgroups in adjustment logic

### DIFF
--- a/pkg/adaptation/result.go
+++ b/pkg/adaptation/result.go
@@ -693,6 +693,11 @@ func (r *result) adjustResources(resources *LinuxResources, plugin string) error
 		reply.HugepageLimits = append(reply.HugepageLimits, l)
 	}
 
+	for _, d := range resources.Devices {
+		container.Devices = append(container.Devices, d)
+		reply.Devices = append(reply.Devices, d)
+	}
+
 	if len(resources.Unified) != 0 {
 		for k, v := range resources.Unified {
 			if err := r.owners.claimUnified(id, k, plugin); err != nil {

--- a/pkg/api/resources.go
+++ b/pkg/api/resources.go
@@ -189,6 +189,15 @@ func (r *LinuxResources) Copy() *LinuxResources {
 	}
 	o.BlockioClass = String(r.BlockioClass)
 	o.RdtClass = String(r.RdtClass)
+	for _, d := range r.Devices {
+		o.Devices = append(o.Devices, &LinuxDeviceCgroup{
+			Allow:  d.Allow,
+			Type:   d.Type,
+			Access: d.Access,
+			Major:  Int64(d.Major),
+			Minor:  Int64(d.Minor),
+		})
+	}
 
 	return o
 }

--- a/pkg/runtime-tools/generate/generate.go
+++ b/pkg/runtime-tools/generate/generate.go
@@ -276,6 +276,9 @@ func (g *Generator) AdjustResources(r *nri.LinuxResources) error {
 	if v := r.GetPids(); v != nil {
 		g.SetLinuxResourcesPidsLimit(v.GetLimit())
 	}
+	for _, d := range r.Devices {
+		g.AddLinuxResourcesDevice(d.Allow, d.Type, d.Major.Get(), d.Minor.Get(), d.Access)
+	}
 	if g.checkResources != nil {
 		if err := g.checkResources(g.Config.Linux.Resources); err != nil {
 			return fmt.Errorf("failed to adjust resources in OCI Spec: %w", err)


### PR DESCRIPTION
This is a very useful feature for cases where we'd like to give wildcard device permissions to the cgroup, e.g. `--device-cgroup-rule 'c *:* rwm'` which is possible in both Podman and Docker.

Found out the hard way that `Linux.Resources.Devices` are not processed at all.

If I understood the claim logic correctly, it is to prevent multiple plugins from overriding each other. But the cgroup rules array is a layered permission list, e.g. it starts with a deny all rule and allow rules are appended so different plugins may append different rules. That's why I didn't add a `claimDeviceCgroup` but happy to change.

I've validated this change with containerd `1.7.27` that has this patch on top of NRI `0.8.0`.