### PR TITLE
plugins: use noderesource.dev domain

### DIFF
--- a/plugins/device-injector/README.md
+++ b/plugins/device-injector/README.md
@@ -5,14 +5,33 @@ containers using pod annotations.
 
 ### Device Annotations
 
-Devices are annotated using the `devices.nri.io` annotation key prefix.
-The key `devices.nri.io/container.$CONTAINER_NAME` annotates devices to
-be injected into `$CONTAINER_NAME`. The keys `devices.nri.io` and
-`devices.nri.io/pod` annotate devices to be injected into containers
-without any other, container-specific device annotations. Only one of
-these latter two annotations will be ever taken into account. If both are
-present, `devices.nri.io/pod` is used and `devices.nri.io` is silently
-ignored, otherwise `devices.nri.io`, in the absence of additional suffix text,  is processed as shorthand for the `devices.nri.io/pod` annotation. The order of precedence is `devices.nri.io/container.$CONTAINER_NAME` is used, unless not present, then `devices.nri.io/pod` followed by the `devices.nri.io` shorthand annotation.
+Devices are annotated using the `devices.noderesource.dev` annotation key
+prefix. The key `devices.noderesource.dev/container.$CONTAINER_NAME` annotates
+devices to be injected into `$CONTAINER_NAME`. The keys
+`devices.noderesource.dev` and `devices.noderesource.dev/pod` annotate devices
+to be injected into containers without any other, container-specific device
+annotations. Only one of these latter two annotations will be ever taken into
+account. If both are present, `devices.noderesource.dev/pod` is used and
+`devices.noderesource.dev` is silently ignored, otherwise
+`devices.noderesource.dev`, in the absence of additional suffix text, is
+processed as shorthand for the `devices.noderesource.dev/pod` annotation.
+
+For compatibility with older versions of this plugin, the prefix
+`devices.nri.io` is also supported and follows identical rules. When
+equivalently-specific annotations are present with both the
+`devices.noderesource.dev` prefix and the `devices.nri.io` prefix, the
+annotation with the `devices.noderesource.dev` prefix is used and
+`devices.nri.io` is silently ignored. In all cases, the most-specific
+annotation is preferred regardless of prefix.
+
+The order of precedence is as follows:
+
+1. `devices.noderesource.dev/container.$CONTAINER_NAME`
+2. `devices.nri.io/container.$CONTAINER_NAME`
+3. `devices.noderesource.dev/pod`
+4. `devices.nri.io/pod`
+5. `devices.noderesource.dev`
+6. `devices.nri.io`
 
 The annotation value syntax for device injection is
 
@@ -33,8 +52,10 @@ The annotation value syntax for device injection is
 ### CDI Device Annotations
 
 CDI devices are annotated in a similar manner to devices, but using the
-`cdi-devices.nri.io` annotation key prefix. The annotation value for CDI
-devices is the list of CDI device names to inject.
+`cdi-devices.noderesource.dev` annotation key prefix. As with devices, the
+`cdi-devices.nri.io` annotation key prefix is also supported.
+
+The annotation value for CDI devices is the list of CDI device names to inject.
 
 For instance, the following annotation
 
@@ -42,29 +63,31 @@ For instance, the following annotation
 metadata:
   name: bash
   annotations:
-    cdi-devices.nri.io/container.c0: |
+    cdi-devices.noderesource.dev/container.c0: |
       - vendor0.com/device=null
-    cdi-devices.nri.io/container.c1: |
+    cdi-devices.noderesource.dev/container.c1: |
       - vendor0.com/device=zero
-    cdi-devices.nri.io/container.c2: |
+    cdi-devices.noderesource.dev/container.c2: |
       - vendor0.com/device=dev0
       - vendor1.com/device=dev0
       - vendor1.com/device=dev1
-    cdi-devices.nri.io/container.mgmt: |
+    cdi-devices.noderesource.dev/container.mgmt: |
       - vendor0.com/device=all
 ```
 
-requests the injection of the CDI device vendor0.com/device=null to container
-c0, the injection of the CDI device vendor0.com/device=zero to container c1,
-the injection of the CDI devices vendor0.com/device=dev0, vendor1.com/device=dev0
-and vendor1.com/device=dev1 to container c2, and the injection of the CDI device
-vendor0.com/device=all to container mgmt.
+requests the injection of the CDI device `vendor0.com/device=null` to container
+c0, the injection of the CDI device `vendor0.com/device=zero` to container c1,
+the injection of the CDI devices `vendor0.com/device=dev0`,
+`vendor1.com/device=dev0` and `vendor1.com/device=dev1` to container c2, and
+the injection of the CDI device `vendor0.com/device=all` to container mgmt.
 
 ### Mount Annotations
 
 Mounts are annotated in a similar manner to devices, but using the
-`mounts.nri.io` annotation key prefix. The annotation value syntax for mount
-injection is
+`mounts.noderesource.dev` annotation key prefix. As with devices, the
+`mounts.nri.io` annotation key prefix is also supported.
+
+The annotation value syntax for mount injection is
 
 ```
   - source: <mount source0>

--- a/plugins/device-injector/device-injector.go
+++ b/plugins/device-injector/device-injector.go
@@ -31,12 +31,18 @@ import (
 )
 
 const (
-	// Prefix of the key used for device annotations.
-	deviceKey = "devices.nri.io"
-	// Prefix of the key used for mount annotations.
-	mountKey = "mounts.nri.io"
-	// Prefix of the key used for CDI device annotations.
-	cdiDeviceKey = "cdi-devices.nri.io"
+	// deviceKey is the prefix of the key used for device annotations.
+	deviceKey = "devices.noderesource.dev"
+	// Deprecated: Prefix of the key used for device annotations.
+	oldDeviceKey = "devices.nri.io"
+	// mountKey is the prefix of the key used for mount annotations.
+	mountKey = "mounts.noderesource.dev"
+	// Deprecated: Prefix of the key used for mount annotations.
+	oldMountKey = "mounts.nri.io"
+	// cdiDeviceKey is the prefix of the key used for CDI device annotations.
+	cdiDeviceKey = "cdi-devices.noderesource.dev"
+	// Deprecated: Prefix of the key used for CDI device annotations.
+	oldCDIDeviceKey = "cdi-devices.nri.io"
 )
 
 var (
@@ -125,8 +131,8 @@ func parseDevices(ctr string, annotations map[string]string) ([]device, error) {
 		devices []device
 	)
 
-	annotation := getAnnotation(annotations, deviceKey, ctr)
-	if annotation == nil {
+	annotation := getAnnotation(annotations, deviceKey, oldDeviceKey, ctr)
+	if len(annotation) == 0 {
 		return nil, nil
 	}
 
@@ -171,8 +177,8 @@ func parseCDIDevices(ctr string, annotations map[string]string) ([]string, error
 		cdiDevices []string
 	)
 
-	annotation := getAnnotation(annotations, cdiDeviceKey, ctr)
-	if annotation == nil {
+	annotation := getAnnotation(annotations, cdiDeviceKey, oldCDIDeviceKey, ctr)
+	if len(annotation) == 0 {
 		return nil, nil
 	}
 
@@ -214,8 +220,8 @@ func parseMounts(ctr string, annotations map[string]string) ([]mount, error) {
 		mounts []mount
 	)
 
-	annotation := getAnnotation(annotations, mountKey, ctr)
-	if annotation == nil {
+	annotation := getAnnotation(annotations, mountKey, oldMountKey, ctr)
+	if len(annotation) == 0 {
 		return nil, nil
 	}
 
@@ -226,11 +232,14 @@ func parseMounts(ctr string, annotations map[string]string) ([]mount, error) {
 	return mounts, nil
 }
 
-func getAnnotation(annotations map[string]string, mainKey, ctr string) []byte {
+func getAnnotation(annotations map[string]string, mainKey, oldKey, ctr string) []byte {
 	for _, key := range []string{
 		mainKey + "/container." + ctr,
+		oldKey + "/container." + ctr,
 		mainKey + "/pod",
+		oldKey + "/pod",
 		mainKey,
+		oldKey,
 	} {
 		if value, ok := annotations[key]; ok {
 			return []byte(value)

--- a/plugins/device-injector/sample-device-inject.yaml
+++ b/plugins/device-injector/sample-device-inject.yaml
@@ -11,17 +11,17 @@ metadata:
   labels:
     app: bbdev0
   annotations:
-    devices.nri.io/container.c0: |+
+    devices.noderesource.dev/container.c0: |+
       - path: /dev/nri-null
         type: c
         major: 1
         minor: 3
-    devices.nri.io/container.c1: |+
+    devices.noderesource.dev/container.c1: |+
       - path: /dev/nri-zero
         type: c
         major: 1
         minor: 5
-    mounts.nri.io/container.c2: |+
+    mounts.noderesource.dev/container.c2: |+
       - source: /home
         destination: /host-home
         type: bind

--- a/plugins/network-device-injector/README.md
+++ b/plugins/network-device-injector/README.md
@@ -21,7 +21,8 @@ and any modification can impact the existing system networking.
 
 ### Network Device Annotations
 
-Network devices are annotated using the `netdevices.nri.containerd.io` annotation key prefix.
+Network devices are annotated using the `netdevices.noderesource.dev` annotation key prefix.
+For compatibility with older versions of this plugin, the `netdevices.nri.containerd.io` annotation key prefix is also accepted.
 Network devices are defined at the Pod level, since are part of the network namespace.
 
 The annotation syntax for network device injection is

--- a/plugins/network-device-injector/network-device-injector.go
+++ b/plugins/network-device-injector/network-device-injector.go
@@ -36,7 +36,8 @@ import (
 
 const (
 	// Prefix of the key used for network device annotations.
-	netdeviceKey = "netdevices.nri.containerd.io"
+	netdeviceKey    = "netdevice.noderesource.dev"
+	oldNetdeviceKey = "netdevices.nri.containerd.io" // Deprecated
 )
 
 var (
@@ -194,7 +195,9 @@ func parseNetdevices(annotations map[string]string) ([]netdevice, error) {
 	// look up effective device annotation and unmarshal devices
 	for _, key = range []string{
 		netdeviceKey + "/pod",
+		oldNetdeviceKey + "/pod",
 		netdeviceKey,
+		oldNetdeviceKey,
 	} {
 		if value, ok := annotations[key]; ok {
 			annotation = []byte(value)

--- a/plugins/network-device-injector/sample-network-device-inject.yaml
+++ b/plugins/network-device-injector/sample-network-device-inject.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app: bbdev0
   annotations:
-    netdevices.nri.io: |+
+    netdevices.noderesource.dev: |+
       - name: dummy0
         new_name: eth33
         address: 192.168.2.2

--- a/plugins/ulimit-adjuster/README.md
+++ b/plugins/ulimit-adjuster/README.md
@@ -5,9 +5,10 @@ This sample plugin can adjust ulimits for containers using pod annotations.
 ### Annotations
 
 ulimits are annotated using the key
-`ulimits.nri.containerd.io/container.$CONTAINER_NAME`, which adjusts ulimits
-for `$CONTAINER_NAME`.  The ulimit names are the valid names of Linux resource
-limits, which can be seen on the
+`ulimits.noderesource.dev/container.$CONTAINER_NAME`, which adjusts ulimits
+for `$CONTAINER_NAME`. For compatibility, this plugin also accepts annotations
+named `ulimits.nri.containerd.io/container.$CONTAINER_NAME`. The ulimit names
+are the valid names of Linux resource limits, which can be seen on the
 [`setrlimit(2)` manual page](https://linux.die.net/man/2/setrlimit).
 
 The annotation syntax for ulimit adjustment is
@@ -23,7 +24,7 @@ The annotation syntax for ulimit adjustment is
 ```
 
 All fields are mandatory (`soft` and `hard` will be interpreted as 0 if
-missing).  The `type` field accepts names in uppercase letters
+missing). The `type` field accepts names in uppercase letters
 ("RLIMIT_NOFILE"), lowercase letters ("rlimit_memlock"), and omitting the
 "RLIMIT_" prefix ("nproc").
 
@@ -32,5 +33,5 @@ missing).  The `type` field accepts names in uppercase letters
 You can test this plugin using a kubernetes cluster/node with a container
 runtime that has NRI support enabled. Start the plugin on the target node
 (`ulimit-adjuster -idx 10`), create a pod with some annotated ulimits, then
-verify that those get adjusted in the container.  See the
+verify that those get adjusted in the container. See the
 [sample pod spec](sample-ulimit-adjust.yaml) for an example.

--- a/plugins/ulimit-adjuster/adjuster_test.go
+++ b/plugins/ulimit-adjuster/adjuster_test.go
@@ -42,7 +42,7 @@ func TestParseAnnotations(t *testing.T) {
 		"one-valid": {
 			container: "foo",
 			annotations: map[string]string{
-				"ulimits.nri.containerd.io/container.foo": `
+				"ulimits.noderesource.dev/container.foo": `
 - type: RLIMIT_NOFILE
   soft: 123
   hard: 456
@@ -56,7 +56,7 @@ func TestParseAnnotations(t *testing.T) {
 		"multiple-valid": {
 			container: "foo",
 			annotations: map[string]string{
-				"ulimits.nri.containerd.io/container.foo": `
+				"ulimits.noderesource.dev/container.foo": `
 - type: RLIMIT_NOFILE
   soft: 123
   hard: 456
@@ -77,7 +77,7 @@ func TestParseAnnotations(t *testing.T) {
 		"missing-prefix": {
 			container: "foo",
 			annotations: map[string]string{
-				"ulimits.nri.containerd.io/container.foo": `
+				"ulimits.noderesource.dev/container.foo": `
 - type: AS
   soft: 123
   hard: 456
@@ -91,7 +91,7 @@ func TestParseAnnotations(t *testing.T) {
 		"lower-case": {
 			container: "foo",
 			annotations: map[string]string{
-				"ulimits.nri.containerd.io/container.foo": `
+				"ulimits.noderesource.dev/container.foo": `
 - type: rlimit_core
   soft: 123
   hard: 456
@@ -105,7 +105,7 @@ func TestParseAnnotations(t *testing.T) {
 		"lower-case-missing-prefix": {
 			container: "foo",
 			annotations: map[string]string{
-				"ulimits.nri.containerd.io/container.foo": `
+				"ulimits.noderesource.dev/container.foo": `
 - type: cpu
   soft: 123
   hard: 456
@@ -119,7 +119,7 @@ func TestParseAnnotations(t *testing.T) {
 		"invalid-prefix": {
 			container: "foo",
 			annotations: map[string]string{
-				"ulimits.nri.containerd.io/container.foo": `
+				"ulimits.noderesource.dev/container.foo": `
 - type: ULIMIT_NOFILE
   soft: 123
   hard: 456
@@ -129,7 +129,7 @@ func TestParseAnnotations(t *testing.T) {
 		"invalid-rlimit": {
 			container: "foo",
 			annotations: map[string]string{
-				"ulimits.nri.containerd.io/container.foo": `
+				"ulimits.noderesource.dev/container.foo": `
 - type: RLIMIT_FOO
   soft: 123
   hard: 456
@@ -139,7 +139,7 @@ func TestParseAnnotations(t *testing.T) {
 		"one-invalid": {
 			container: "foo",
 			annotations: map[string]string{
-				"ulimits.nri.containerd.io/container.foo": `
+				"ulimits.noderesource.dev/container.foo": `
 - type: RLIMIT_NICE
   soft: 456
   hard: 789


### PR DESCRIPTION
The nri.io domain is not owned or controlled by CNCF and its use should be discouraged.  This commit adds support for the new noderesource.dev domain, which is a CNCF-owned domain.