### PR TITLE
don't exit on close

### DIFF
--- a/pkg/stub/stub.go
+++ b/pkg/stub/stub.go
@@ -504,7 +504,7 @@ func (stub *stub) Run(ctx context.Context) error {
 
 	err = <-stub.srvErrC
 	if err == ttrpc.ErrServerClosed {
-		return nil
+		log.Infof(noCtx, "ttrpc server closed %s : %v", stub.Name(), err)
 	}
 
 	return err
@@ -591,8 +591,6 @@ func (stub *stub) connClosed() {
 		stub.onClose()
 		return
 	}
-
-	os.Exit(0)
 }
 
 //


### PR DESCRIPTION
It is not a good practice for a library to unilaterally decide to terminate the entire program and, since it is imported, is super hard to debug for nri plugins authors that only see the program exit without any obvious reason.

Change-Id: Ic72612d4e8421a2eb301d33dda760765461929d7