### PR TITLE
ci: use latest go patch version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: ["1.24.3"]
+        go-version: ["1.24.x"]
         os: [ubuntu-22.04]
 
     steps:
@@ -99,7 +99,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: ["1.24.3"]
+        go-version: ["1.24.x"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
There is no reason to stick to 1.24.3, means we can re-introduce the go1.24.x tag to allow newer ones in CI.