### PR TITLE
readme: list all sample plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,9 +411,12 @@ The following sample plugins exist for NRI:
   - [differ](plugins/differ)
   - [device injector](plugins/device-injector)
   - [network device injector](plugins/network-device-injector)
+  - [network logger](plugins/network-logger)
   - [OCI hook injector](plugins/hook-injector)
   - [ulimit adjuster](plugins/ulimit-adjuster)
   - [NRI v0.1.0 plugin adapter](plugins/v010-adapter)
+  - [WebAssembly plugin](plugins/wasm)
+  - [template](plugins/template)
 
 Please see the documentation of these plugins for further details
 about what and how each of these plugins can be used for.

--- a/plugins/template/README.md
+++ b/plugins/template/README.md
@@ -1,0 +1,5 @@
+# Template NRI plugin
+
+This is a minimal example plugin that demonstrates how to interact with
+container lifecycle events with NRI. This plugin can be deployed for testing
+and demonstration purposes and used as a base for implementing new NRI plugins.

--- a/plugins/wasm/README.md
+++ b/plugins/wasm/README.md
@@ -1,0 +1,4 @@
+# NRI WebAssembly plugin
+
+This is a minimal example to demonstrate how to build an NRI plugin as a WASM
+binary.


### PR DESCRIPTION
Also add minimal readme for the template and wasm plugins.

The default-validator plugin is left out as it cannot be built as an external plugin (without changes).