### PR TITLE
plugins: hard code plugin names

### DIFF
--- a/plugins/device-injector/device-injector.go
+++ b/plugins/device-injector/device-injector.go
@@ -413,10 +413,9 @@ func dump(args ...interface{}) {
 
 func main() {
 	var (
-		pluginName string
-		pluginIdx  string
-		opts       []stub.Option
-		err        error
+		pluginIdx string
+		opts      []stub.Option
+		err       error
 	)
 
 	log = logrus.StandardLogger()
@@ -424,14 +423,11 @@ func main() {
 		PadLevelText: true,
 	})
 
-	flag.StringVar(&pluginName, "name", "", "plugin name to register to NRI")
 	flag.StringVar(&pluginIdx, "idx", "", "plugin index to register to NRI")
 	flag.BoolVar(&verbose, "verbose", false, "enable (more) verbose logging")
 	flag.Parse()
 
-	if pluginName != "" {
-		opts = append(opts, stub.WithPluginName(pluginName))
-	}
+	opts = append(opts, stub.WithPluginName("device-injector"))
 	if pluginIdx != "" {
 		opts = append(opts, stub.WithPluginIdx(pluginIdx))
 	}

--- a/plugins/differ/nri-differ.go
+++ b/plugins/differ/nri-differ.go
@@ -332,7 +332,7 @@ func (p *plugin) printYamlDiff(apifunc string, obj string, origValue interface{}
 	}
 }
 
-func startPlugin(wg *sync.WaitGroup, pluginName string, pluginIdx int) {
+func startPlugin(wg *sync.WaitGroup, pluginIdx int) {
 	var (
 		opts []stub.Option
 		err  error
@@ -342,9 +342,7 @@ func startPlugin(wg *sync.WaitGroup, pluginName string, pluginIdx int) {
 
 	idxStr := fmt.Sprintf("%02d", pluginIdx)
 
-	if pluginName != "" {
-		opts = append(opts, stub.WithPluginName(pluginName))
-	}
+	opts = append(opts, stub.WithPluginName("Differ"))
 	if idxStr != "" {
 		opts = append(opts, stub.WithPluginIdx(idxStr))
 	}
@@ -427,7 +425,7 @@ func main() {
 
 		wg.Add(1)
 
-		go startPlugin(wg, "Differ", idx)
+		go startPlugin(wg, idx)
 	}
 
 	entry := indices[prevIndex]

--- a/plugins/hook-injector/hook-injector.go
+++ b/plugins/hook-injector/hook-injector.go
@@ -135,7 +135,6 @@ func dump(args ...interface{}) {
 
 func main() {
 	var (
-		pluginName   string
 		pluginIdx    string
 		disableWatch bool
 		opts         []stub.Option
@@ -148,15 +147,12 @@ func main() {
 		PadLevelText: true,
 	})
 
-	flag.StringVar(&pluginName, "name", "", "plugin name to register to NRI")
 	flag.StringVar(&pluginIdx, "idx", "", "plugin index to register to NRI")
 	flag.BoolVar(&verbose, "verbose", false, "enable (more) verbose logging")
 	flag.BoolVar(&disableWatch, "disableWatch", false, "disable watching hook directories for new hooks")
 	flag.Parse()
 
-	if pluginName != "" {
-		opts = append(opts, stub.WithPluginName(pluginName))
-	}
+	opts = append(opts, stub.WithPluginName("hook-injector"))
 	if pluginIdx != "" {
 		opts = append(opts, stub.WithPluginIdx(pluginIdx))
 	}

--- a/plugins/logger/nri-logger.go
+++ b/plugins/logger/nri-logger.go
@@ -216,11 +216,10 @@ func dump(args ...interface{}) {
 
 func main() {
 	var (
-		pluginName string
-		pluginIdx  string
-		events     string
-		opts       []stub.Option
-		err        error
+		pluginIdx string
+		events    string
+		opts      []stub.Option
+		err       error
 	)
 
 	log = logrus.StandardLogger()
@@ -228,7 +227,6 @@ func main() {
 		PadLevelText: true,
 	})
 
-	flag.StringVar(&pluginName, "name", "", "plugin name to register to NRI")
 	flag.StringVar(&pluginIdx, "idx", "", "plugin index to register to NRI")
 	flag.StringVar(&events, "events", "all", "comma-separated list of events to subscribe for")
 	flag.StringVar(&cfg.LogFile, "log-file", "", "logfile name, if logging to a file")
@@ -246,9 +244,7 @@ func main() {
 		log.SetOutput(f)
 	}
 
-	if pluginName != "" {
-		opts = append(opts, stub.WithPluginName(pluginName))
-	}
+	opts = append(opts, stub.WithPluginName("logger"))
 	if pluginIdx != "" {
 		opts = append(opts, stub.WithPluginIdx(pluginIdx))
 	}

--- a/plugins/network-device-injector/network-device-injector.go
+++ b/plugins/network-device-injector/network-device-injector.go
@@ -273,10 +273,9 @@ func dump(args ...interface{}) {
 
 func main() {
 	var (
-		pluginName string
-		pluginIdx  string
-		opts       []stub.Option
-		err        error
+		pluginIdx string
+		opts      []stub.Option
+		err       error
 	)
 
 	log = logrus.StandardLogger()
@@ -284,14 +283,11 @@ func main() {
 		PadLevelText: true,
 	})
 
-	flag.StringVar(&pluginName, "name", "", "plugin name to register to NRI")
 	flag.StringVar(&pluginIdx, "idx", "", "plugin index to register to NRI")
 	flag.BoolVar(&verbose, "verbose", false, "enable (more) verbose logging")
 	flag.Parse()
 
-	if pluginName != "" {
-		opts = append(opts, stub.WithPluginName(pluginName))
-	}
+	opts = append(opts, stub.WithPluginName("network-device-injector"))
 	if pluginIdx != "" {
 		opts = append(opts, stub.WithPluginIdx(pluginIdx))
 	}

--- a/plugins/network-logger/plugin.go
+++ b/plugins/network-logger/plugin.go
@@ -83,9 +83,8 @@ func (p *plugin) onClose() {
 
 func main() {
 	var (
-		pluginName string
-		pluginIdx  string
-		err        error
+		pluginIdx string
+		err       error
 	)
 
 	log = logrus.StandardLogger()
@@ -93,7 +92,6 @@ func main() {
 		PadLevelText: true,
 	})
 
-	flag.StringVar(&pluginName, "network-logger", "", "plugin name to register to NRI")
 	flag.StringVar(&pluginIdx, "idx", "", "plugin index to register to NRI")
 	flag.Parse()
 
@@ -101,9 +99,7 @@ func main() {
 	opts := []stub.Option{
 		stub.WithOnClose(p.onClose),
 	}
-	if pluginName != "" {
-		opts = append(opts, stub.WithPluginName(pluginName))
-	}
+	opts = append(opts, stub.WithPluginName("network-logger"))
 	if pluginIdx != "" {
 		opts = append(opts, stub.WithPluginIdx(pluginIdx))
 	}

--- a/plugins/template/plugin.go
+++ b/plugins/template/plugin.go
@@ -177,7 +177,7 @@ func main() {
 		PadLevelText: true,
 	})
 
-	flag.StringVar(&pluginName, "name", "", "plugin name to register to NRI")
+	flag.StringVar(&pluginName, "name", "template", "plugin name to register to NRI")
 	flag.StringVar(&pluginIdx, "idx", "", "plugin index to register to NRI")
 	flag.Parse()
 

--- a/plugins/ulimit-adjuster/adjuster.go
+++ b/plugins/ulimit-adjuster/adjuster.go
@@ -59,11 +59,11 @@ var (
 )
 
 func main() {
+	const pluginName = "ulimit-adjuster"
 	var (
-		pluginName string
-		pluginIdx  string
-		verbose    bool
-		opts       []stub.Option
+		pluginIdx string
+		verbose   bool
+		opts      []stub.Option
 	)
 
 	l := logrus.StandardLogger()
@@ -71,7 +71,6 @@ func main() {
 		PadLevelText: true,
 	})
 
-	flag.StringVar(&pluginName, "name", "", "plugin name to register to NRI")
 	flag.StringVar(&pluginIdx, "idx", "", "plugin index to register to NRI")
 	flag.BoolVar(&verbose, "verbose", false, "enable (more) verbose logging")
 	flag.Parse()
@@ -82,9 +81,7 @@ func main() {
 		l.SetLevel(logrus.DebugLevel)
 	}
 
-	if pluginName != "" {
-		opts = append(opts, stub.WithPluginName(pluginName))
-	}
+	opts = append(opts, stub.WithPluginName(pluginName))
 	if pluginIdx != "" {
 		opts = append(opts, stub.WithPluginIdx(pluginIdx))
 	}

--- a/plugins/v010-adapter/v010-adapter.go
+++ b/plugins/v010-adapter/v010-adapter.go
@@ -195,9 +195,8 @@ func namespacesToSlice(namespaces []*api.LinuxNamespace) []oci.LinuxNamespace {
 
 func main() {
 	var (
-		pluginName string
-		pluginIdx  string
-		err        error
+		pluginIdx string
+		err       error
 	)
 
 	log = logrus.StandardLogger()
@@ -205,7 +204,6 @@ func main() {
 		PadLevelText: true,
 	})
 
-	flag.StringVar(&pluginName, "name", "", "plugin name to register to NRI")
 	flag.StringVar(&pluginIdx, "idx", "", "plugin index to register to NRI")
 	flag.Parse()
 
@@ -213,9 +211,7 @@ func main() {
 	opts := []stub.Option{
 		stub.WithOnClose(p.onClose),
 	}
-	if pluginName != "" {
-		opts = append(opts, stub.WithPluginName(pluginName))
-	}
+	opts = append(opts, stub.WithPluginName("v010-adapter"))
 	if pluginIdx != "" {
 		opts = append(opts, stub.WithPluginIdx(pluginIdx))
 	}


### PR DESCRIPTION
Drop the -name argument for plugins, except for the template plugin where the default is set to "template". Ensures consistent name accross environments.

An less invasive alternative would be to change the flag default values.