### PR TITLE
plugins/hook-injector: more verbosity on -verbose

### DIFF
--- a/plugins/hook-injector/hook-injector.go
+++ b/plugins/hook-injector/hook-injector.go
@@ -161,6 +161,10 @@ func main() {
 		opts = append(opts, stub.WithPluginIdx(pluginIdx))
 	}
 
+	if verbose {
+		logrus.SetLevel(logrus.DebugLevel)
+	}
+
 	p := &plugin{}
 	if p.stub, err = stub.New(p, opts...); err != nil {
 		log.Errorf("failed to create plugin stub: %v", err)


### PR DESCRIPTION
Provides debug logs from the hooks manager, too.