### PR TITLE
plugins: consistent exit behavior on ttrpc close

### DIFF
--- a/plugins/differ/nri-differ.go
+++ b/plugins/differ/nri-differ.go
@@ -257,8 +257,8 @@ func (p *plugin) RemoveContainer(_ context.Context, pod *api.PodSandbox, contain
 }
 
 func (p *plugin) onClose() {
-	log.Infof("stopped")
-	os.Exit(0)
+	log.Infof("Connection to the runtime lost, exiting...")
+	os.Exit(1)
 }
 
 // Dump one or more objects, with an optional global prefix and per-object tags.

--- a/plugins/logger/nri-logger.go
+++ b/plugins/logger/nri-logger.go
@@ -177,7 +177,8 @@ func (p *plugin) ValidateContainerAdjustment(_ context.Context, req *api.Validat
 }
 
 func (p *plugin) onClose() {
-	os.Exit(0)
+	log.Infof("Connection to the runtime lost, exiting...")
+	os.Exit(1)
 }
 
 // Dump one or more objects, with an optional global prefix and per-object tags.

--- a/plugins/network-logger/plugin.go
+++ b/plugins/network-logger/plugin.go
@@ -78,7 +78,7 @@ func (p *plugin) RemovePodSandbox(_ context.Context, pod *api.PodSandbox) error 
 
 func (p *plugin) onClose() {
 	log.Infof("Connection to the runtime lost, exiting...")
-	os.Exit(0)
+	os.Exit(1)
 }
 
 func main() {

--- a/plugins/template/plugin.go
+++ b/plugins/template/plugin.go
@@ -162,7 +162,7 @@ func (p *plugin) RemoveContainer(_ context.Context, pod *api.PodSandbox, ctr *ap
 
 func (p *plugin) onClose() {
 	log.Infof("Connection to the runtime lost, exiting...")
-	os.Exit(0)
+	os.Exit(1)
 }
 
 func main() {

--- a/plugins/v010-adapter/v010-adapter.go
+++ b/plugins/v010-adapter/v010-adapter.go
@@ -148,7 +148,7 @@ func (p *plugin) StopContainer(_ context.Context, pod *api.PodSandbox, ctr *api.
 
 func (p *plugin) onClose() {
 	log.Infof("Connection to the runtime lost, exiting...")
-	os.Exit(0)
+	os.Exit(1)
 }
 
 func sandboxFromPod(pod *api.PodSandbox) *nri.Sandbox {


### PR DESCRIPTION
Make those sample plugins which have OnClose defined exit in a similar fashion, with a log message and exit status 1. This is consistent with the rest of the sample plugins which also exit with status 1 in this case (but a different log output).