### PR TITLE
plugins/hook-injector: correct the hook configs

### DIFF
--- a/plugins/hook-injector/etc/containers/oci/hooks.d/always-inject.json
+++ b/plugins/hook-injector/etc/containers/oci/hooks.d/always-inject.json
@@ -2,7 +2,7 @@
     "version": "1.0.0",
     "hook": {
         "path": "/usr/local/sbin/demo-hook.sh",
-        "args": ["this", "hook", "is", "always", "injected"],
+        "args": ["demo-hook.sh", "this", "hook", "is", "always", "injected"],
         "env": [
             "DEMO_HOOK_ALWAYS_INJECTED=true"
         ]

--- a/plugins/hook-injector/etc/containers/oci/hooks.d/busybox-inject.json
+++ b/plugins/hook-injector/etc/containers/oci/hooks.d/busybox-inject.json
@@ -2,7 +2,7 @@
     "version": "1.0.0",
     "hook": {
         "path": "/usr/local/sbin/demo-hook.sh",
-        "args": ["this", "is", "injected", "into", "busybox"],
+        "args": ["demo-hook.sh", "this", "is", "injected", "into", "busybox"],
         "env": [
             "DEMO_HOOK_BUSYBOX_INJECTED=true",
             "DEMO_HOOK_ARGV0=busybox"


### PR DESCRIPTION
In the OCI hook configureation args[0] will not be passed to the hook script as an arg (by convention args[0] is the command).