### PR TITLE
Add dockerized target for building proto files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,13 @@ FORCE:
 
 build-proto: $(PROTO_GOFILES)
 
+.PHONY: build-proto-dockerized
+build-proto-dockerized:
+	$(Q)docker build --build-arg ARTIFACTS="$(dir $(PROTO_GOFILES))" --target final \
+		--output type=local,dest=$(RESOLVED_PWD) \
+		-f hack/Dockerfile.buildproto .
+	$(Q)tar xf artifacts.tgz && rm -f artifacts.tgz
+
 build-plugins: $(PLUGINS)
 
 build-check:

--- a/hack/Dockerfile.buildproto
+++ b/hack/Dockerfile.buildproto
@@ -1,0 +1,36 @@
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+ARG GO_VERSION=1.24
+ARG BASE_DEBIAN_DISTRO="bookworm"
+
+FROM golang:${GO_VERSION}-${BASE_DEBIAN_DISTRO} AS builder
+ARG ARTIFACTS
+
+WORKDIR /go/src
+
+RUN apt-get update && apt-get install -y unzip
+
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+    --mount=src=.,target=. \
+    make install-protoc-dependencies install-ttrpc-plugin install-wasm-plugin install-protoc
+
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+    --mount=src=.,target=.,rw=true \
+    make build-proto && \
+    tar czf /artifacts.tgz ${ARTIFACTS}
+
+FROM scratch AS final
+
+COPY --from=builder /artifacts.tgz .


### PR DESCRIPTION
Makes it possible to build api files without contaminating the host system.