### PR TITLE
Downgrade go to require 1.24.0

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/nri/examples
 
-go 1.22.0
+go 1.24.0
 
 require (
 	github.com/containerd/cgroups v1.0.3
@@ -14,7 +14,7 @@ require (
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/godbus/dbus/v5 v5.0.4 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	golang.org/x/sys v0.21.0 // indirect
+	golang.org/x/sys v0.31.0 // indirect
 )
 
 replace github.com/containerd/nri => ../

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -69,8 +69,8 @@ golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
-golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
+golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/nri
 
-go 1.24.3
+go 1.24.0
 
 require (
 	github.com/containerd/ttrpc v1.2.7

--- a/plugins/device-injector/go.mod
+++ b/plugins/device-injector/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/nri/plugins/device-injector
 
-go 1.24.3
+go 1.24.0
 
 require (
 	github.com/containerd/nri v0.6.1

--- a/plugins/differ/go.mod
+++ b/plugins/differ/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/nri/plugins/differ
 
-go 1.24.3
+go 1.24.0
 
 require (
 	github.com/containerd/nri v0.6.1

--- a/plugins/hook-injector/go.mod
+++ b/plugins/hook-injector/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/nri/plugins/hook-injector
 
-go 1.24.3
+go 1.24.0
 
 require (
 	github.com/containerd/nri v0.6.1

--- a/plugins/logger/go.mod
+++ b/plugins/logger/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/nri/plugins/logger
 
-go 1.24.3
+go 1.24.0
 
 require (
 	github.com/containerd/nri v0.6.1

--- a/plugins/network-device-injector/go.mod
+++ b/plugins/network-device-injector/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/nri/plugins/network-device-injector
 
-go 1.24.3
+go 1.24.0
 
 require (
 	github.com/containerd/nri v0.6.1

--- a/plugins/network-logger/go.mod
+++ b/plugins/network-logger/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/nri/plugins/network-logger
 
-go 1.24.3
+go 1.24.0
 
 require (
 	github.com/containerd/nri v0.6.1

--- a/plugins/template/go.mod
+++ b/plugins/template/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/nri/plugins/template
 
-go 1.24.3
+go 1.24.0
 
 require (
 	github.com/containerd/nri v0.6.1

--- a/plugins/ulimit-adjuster/go.mod
+++ b/plugins/ulimit-adjuster/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/nri/plugins/ulimit-adjuster
 
-go 1.24.3
+go 1.24.0
 
 replace github.com/containerd/nri => ../..
 

--- a/plugins/v010-adapter/go.mod
+++ b/plugins/v010-adapter/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/nri/plugins/v010-adapter
 
-go 1.24.3
+go 1.24.0
 
 require (
 	github.com/containerd/containerd v1.7.28

--- a/plugins/wasm/go.mod
+++ b/plugins/wasm/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/nri/plugins/wasm
 
-go 1.24.3
+go 1.24.0
 
 require github.com/containerd/nri v0.6.1
 


### PR DESCRIPTION
Require the lowest available go version to increase compatibility with other projects. 

Per: https://github.com/containerd/nri/commit/f6f8d03795231aae8c7eab14fcadfa051b93d713#r164441839