### PR TITLE
.gitignore: revert hastily reviewed editor-specific addition.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+# If you want to ignore files created by your editor/tools, please consider a
+# [global .gitignore](https://help.github.com/articles/ignoring-files).
+
 build/


### PR DESCRIPTION
Revert recent editor-specific addition to .gitignore, and add a comment about favoring global gitignore for such settings.