### PR TITLE
golangci: disable QF1008 from staticcheck linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,6 +35,9 @@ linters:
       - linters:
           - revive
         text: "package-comments:"
+      - linters:
+          - staticcheck
+        text: "QF1008:"
 
 formatters:
   enable:


### PR DESCRIPTION
Disable:

    QF1008: could remove embedded field "Generator" from selector