### PR TITLE
Makefile: build proto files unconditionally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ check-protoc:
 	fi
 
 install-protoc install-protobuf:
-	$(Q)PROTOBUF_VERSION=$(PROTOBUF_VERSION) ./scripts/install-protobuf
+	$(Q)PROTOBUF_VERSION=$(PROTOBUF_VERSION) INSTALL_DIR=$(PROTOC_PATH) ./scripts/install-protobuf
 
 clean-protoc:
 	$(Q)rm -rf $(PROTOC_PATH)

--- a/hack/Dockerfile.buildproto
+++ b/hack/Dockerfile.buildproto
@@ -23,12 +23,9 @@ WORKDIR /go/src
 RUN apt-get update && apt-get install -y unzip
 
 RUN --mount=type=cache,target=/go/pkg/mod/ \
-    --mount=src=.,target=. \
-    make install-protoc-dependencies install-ttrpc-plugin install-wasm-plugin install-protoc
-
-RUN --mount=type=cache,target=/go/pkg/mod/ \
+    --mount=type=cache,target=/go/tools/,sharing=private \
     --mount=src=.,target=.,rw=true \
-    make build-proto && \
+    make build-proto PROTOC_PATH=/go/tools/protoc && \
     tar czf /artifacts.tgz ${ARTIFACTS}
 
 FROM scratch AS final

--- a/scripts/install-protobuf
+++ b/scripts/install-protobuf
@@ -24,7 +24,7 @@ PROTOBUF_VERSION=${PROTOBUF_VERSION-3.20.1}
 GOARCH=$(go env GOARCH)
 GOOS=$(go env GOOS)
 PROTOBUF_DIR=$(mktemp -d)
-INSTALL_DIR="$PWD/build/tools/protoc"
+INSTALL_DIR=${INSTALL_DIR-"$PWD/build/tools/protoc"}
 
 mkdir -p "$INSTALL_DIR"
 


### PR DESCRIPTION
Ditch the makefile pattern rule which simply doesn't work in scenarios where both the source and the build targets are stored in the git repo (as git operations mangle the time stamps).

So much grey hair avoided when the stuff just force generates everything instead of leaving you wonder why the tools didn't work as expected.