### PR TITLE
adaptation: test with populated initial resources.

### DIFF
--- a/pkg/adaptation/adaptation_suite_test.go
+++ b/pkg/adaptation/adaptation_suite_test.go
@@ -628,6 +628,25 @@ var _ = Describe("Plugin container creation adjustments", func() {
 							"argument",
 							"list",
 						},
+						Linux: &api.LinuxContainer{
+							Resources: &api.LinuxResources{
+								Cpu: &api.LinuxCPU{
+									Shares:          api.UInt64(111),
+									Quota:           api.Int64(222),
+									Period:          api.UInt64(333),
+									RealtimeRuntime: api.Int64(444),
+									RealtimePeriod:  api.UInt64(555),
+								},
+								Memory: &api.LinuxMemory{
+									Limit:            api.Int64(11111),
+									Reservation:      api.Int64(22222),
+									Swap:             api.Int64(33333),
+									Swappiness:       api.UInt64(44444),
+									DisableOomKiller: api.Bool(false),
+									UseHierarchy:     api.Bool(false),
+								},
+							},
+						},
 					}
 				)
 
@@ -903,6 +922,25 @@ var _ = Describe("Plugin container creation adjustments", func() {
 							"original",
 							"argument",
 							"list",
+						},
+						Linux: &api.LinuxContainer{
+							Resources: &api.LinuxResources{
+								Cpu: &api.LinuxCPU{
+									Shares:          api.UInt64(111),
+									Quota:           api.Int64(222),
+									Period:          api.UInt64(333),
+									RealtimeRuntime: api.Int64(444),
+									RealtimePeriod:  api.UInt64(555),
+								},
+								Memory: &api.LinuxMemory{
+									Limit:            api.Int64(11111),
+									Reservation:      api.Int64(22222),
+									Swap:             api.Int64(33333),
+									Swappiness:       api.UInt64(44444),
+									DisableOomKiller: api.Bool(false),
+									UseHierarchy:     api.Bool(false),
+								},
+							},
 						},
 					}
 				)


### PR DESCRIPTION
The current tests for collecting container resource adjustments starts out with fully empty container memory and CPU resources. This allows unintended changes to sneak in unnoticed to the semantics of collected adjustments (see #210). Let's make this less likely by starting with populated initial resources.