### PR TITLE
Install protoc locally in the source tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Install protoc and plugins
         run: |
-          sudo make install-protoc
+          make install-protoc
           make install-protoc-dependencies install-ttrpc-plugin install-wasm-plugin
 
       - name: Force regeneration of protobuf files on build

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Install protoc and plugins
         run: |
-          sudo make install-protoc
+          make install-protoc
           make install-protoc-dependencies install-ttrpc-plugin install-wasm-plugin
 
       - run: make

--- a/scripts/install-protobuf
+++ b/scripts/install-protobuf
@@ -24,12 +24,15 @@ PROTOBUF_VERSION=3.20.1
 GOARCH=$(go env GOARCH)
 GOOS=$(go env GOOS)
 PROTOBUF_DIR=$(mktemp -d)
+INSTALL_DIR="$PWD/build/tools"
+
+mkdir -p "$INSTALL_DIR"
 
 case $GOARCH in
 
 arm64)
 	wget -O "$PROTOBUF_DIR/protobuf" "https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOBUF_VERSION/protoc-$PROTOBUF_VERSION-linux-aarch_64.zip"
-	unzip "$PROTOBUF_DIR/protobuf" -d /usr/local
+	unzip "$PROTOBUF_DIR/protobuf" -d "$INSTALL_DIR"
 	;;
 
 amd64|386)
@@ -38,23 +41,23 @@ amd64|386)
 	elif [ "$GOOS" = linux ]; then
 		wget -O "$PROTOBUF_DIR/protobuf" "https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOBUF_VERSION/protoc-$PROTOBUF_VERSION-linux-x86_64.zip"
 	fi
-	unzip "$PROTOBUF_DIR/protobuf" -d /usr/local
+	unzip -o "$PROTOBUF_DIR/protobuf" -d "$INSTALL_DIR"
 	;;
 
 ppc64le)
 	wget -O "$PROTOBUF_DIR/protobuf" "https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOBUF_VERSION/protoc-$PROTOBUF_VERSION-linux-ppcle_64.zip"
-	unzip "$PROTOBUF_DIR/protobuf" -d /usr/local
+	unzip -o "$PROTOBUF_DIR/protobuf" -d "$INSTALL_DIR"
 	;;
 *)
 	wget -O "$PROTOBUF_DIR/protobuf" "https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOBUF_VERSION/protobuf-cpp-$PROTOBUF_VERSION.zip"
-	unzip "$PROTOBUF_DIR/protobuf" -d /usr/src/protobuf
-	cd "/usr/src/protobuf/protobuf-$PROTOBUF_VERSION"
+    mkdir -p "$INSTALL_DIR/src/protobuf"
+	unzip -o "$PROTOBUF_DIR/protobuf" -d "$INSTALL_DIR/src/protobuf"
+	cd "$INSTALL_DIR/src/protobuf/protobuf-$PROTOBUF_VERSION"
 	./autogen.sh
-	./configure --disable-shared
-	make
-	make check
+	./configure --disable-shared --prefix="$INSTALL_DIR"
+	make -j $(nproc)
+	make check -j $(nproc)
 	make install
-	ldconfig
 	;;
 esac
 rm -rf "$PROTOBUF_DIR"
@@ -62,7 +65,7 @@ rm -rf "$PROTOBUF_DIR"
 # Download status.proto. grpc repos' one seems copied from
 # https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto,
 # but we use grpc's since the repos has tags/releases.
-mkdir -p /usr/local/include/google/rpc
+mkdir -p "$INSTALL_DIR/include/google/rpc"
 curl \
 	-L https://raw.githubusercontent.com/grpc/grpc/v1.45.2/src/proto/grpc/status/status.proto \
-	-o /usr/local/include/google/rpc/status.proto
+	-o "$INSTALL_DIR/include/google/rpc/status.proto"


### PR DESCRIPTION
Install (and use) protoc and plugins under build/tools in the source tree in an attempt to ensure that the correct version of the tooling is always used.