### PR TITLE
adaptation: ensure sync'ed plugins are fully registered in tests.

### DIFF
--- a/pkg/adaptation/suite_test.go
+++ b/pkg/adaptation/suite_test.go
@@ -125,6 +125,7 @@ func (s *Suite) WaitForPluginsToSync(plugins ...*mockPlugin) {
 	for _, plugin := range plugins {
 		Expect(plugin.Wait(PluginSynchronized, timeout)).To(Succeed())
 	}
+	s.runtime.runtime.BlockPluginSync().Unblock() // ensure plugins are fully registered
 }
 
 // Cleanup the test suite.


### PR DESCRIPTION
A plugin having received a sync request is not enough to ensure it has been fully registered on the runtime side (IOW appended to the list of active plugins). When we are waiting for test plugins to start up, use an extra plugin synchronization block/unblock to ensure they are fully registered.