### PR TITLE
Fix wasm example

### DIFF
--- a/plugins/wasm/plugin.go
+++ b/plugins/wasm/plugin.go
@@ -24,9 +24,11 @@ import (
 
 type plugin struct{}
 
-func main() {
+func init() {
 	api.RegisterPlugin(&plugin{})
 }
+
+func main() {}
 
 func log(ctx context.Context, msg string) {
 	api.NewHostFunctions().Log(ctx, &api.LogRequest{


### PR DESCRIPTION
`main` is not called anymore with a WASI reactor, means we have to use `init()` and provide an empty `main()` instead.

Fixes https://github.com/containerd/nri/issues/236