### PR TITLE
runtime-tools: log container adjustments.

### DIFF
--- a/pkg/adaptation/api.go
+++ b/pkg/adaptation/api.go
@@ -104,6 +104,8 @@ type (
 	POSIXRlimit              = api.POSIXRlimit
 	SecurityProfile          = api.SecurityProfile
 	User                     = api.User
+	OwningPlugins            = api.OwningPlugins
+	FieldOwners              = api.FieldOwners
 
 	EventMask = api.EventMask
 )

--- a/pkg/adaptation/suite_test.go
+++ b/pkg/adaptation/suite_test.go
@@ -246,7 +246,8 @@ func (m *mockRuntime) UpdatePodSandbox(ctx context.Context, req *api.UpdatePodSa
 func (m *mockRuntime) CreateContainer(ctx context.Context, req *api.CreateContainerRequest) (*api.CreateContainerResponse, error) {
 	b := m.runtime.BlockPluginSync()
 	defer b.Unblock()
-	return m.runtime.CreateContainer(ctx, req)
+	rpl, _, err := m.runtime.CreateContainer(ctx, req)
+	return rpl, err
 }
 
 func (m *mockRuntime) UpdateContainer(ctx context.Context, req *api.UpdateContainerRequest) (*api.UpdateContainerResponse, error) {

--- a/pkg/api/owners.go
+++ b/pkg/api/owners.go
@@ -49,7 +49,7 @@ func (o *OwningPlugins) ClaimHooks(id, plugin string) error {
 }
 
 func (o *OwningPlugins) HooksOwner(id string) (string, bool) {
-	return o.ownersFor(id).simpleOwner(Field_OciHooks.Key())
+	return o.ownersFor(id).SimpleOwner(Field_OciHooks.Key())
 }
 
 func (o *OwningPlugins) ClearHooks(id, plugin string) {
@@ -148,7 +148,7 @@ func (f *FieldOwners) ClaimHooks(plugin string) error {
 }
 
 func (f *FieldOwners) HooksOwner() (string, bool) {
-	return f.simpleOwner(Field_OciHooks.Key())
+	return f.SimpleOwner(Field_OciHooks.Key())
 }
 
 func (f *FieldOwners) ClearHooks(plugin string) {
@@ -175,7 +175,7 @@ func (f *FieldOwners) ClearRdt(plugin string) {
 }
 
 func (f *FieldOwners) accumulateSimple(field int32, plugin string) {
-	old, ok := f.simpleOwner(field)
+	old, ok := f.SimpleOwner(field)
 	if ok {
 		plugin = old + "," + plugin
 	}
@@ -200,7 +200,7 @@ func (f *FieldOwners) compoundOwnerMap(field int32) (map[string]string, bool) {
 	return m.Owners, true
 }
 
-func (f *FieldOwners) compoundOwner(field int32, key string) (string, bool) {
+func (f *FieldOwners) CompoundOwner(field int32, key string) (string, bool) {
 	if f == nil {
 		return "", false
 	}
@@ -214,7 +214,7 @@ func (f *FieldOwners) compoundOwner(field int32, key string) (string, bool) {
 	return plugin, ok
 }
 
-func (f *FieldOwners) simpleOwner(field int32) (string, bool) {
+func (f *FieldOwners) SimpleOwner(field int32) (string, bool) {
 	if f == nil {
 		return "", false
 	}

--- a/pkg/api/owners_generated.go
+++ b/pkg/api/owners_generated.go
@@ -30,11 +30,11 @@ func (f *FieldOwners) ClaimAnnotation(key, plugin string) error {
 }
 
 func (o *OwningPlugins) AnnotationOwner(id, key string) (string, bool) {
-	return o.ownersFor(id).compoundOwner(Field_Annotations.Key(), key)
+	return o.ownersFor(id).CompoundOwner(Field_Annotations.Key(), key)
 }
 
 func (f *FieldOwners) AnnotationOwner(key string) (string, bool) {
-	return f.compoundOwner(Field_Annotations.Key(), key)
+	return f.CompoundOwner(Field_Annotations.Key(), key)
 }
 
 func (o *OwningPlugins) ClearAnnotation(id, key, plugin string) {
@@ -54,11 +54,11 @@ func (f *FieldOwners) ClaimMount(destination, plugin string) error {
 }
 
 func (o *OwningPlugins) MountOwner(id, destination string) (string, bool) {
-	return o.ownersFor(id).compoundOwner(Field_Mounts.Key(), destination)
+	return o.ownersFor(id).CompoundOwner(Field_Mounts.Key(), destination)
 }
 
 func (f *FieldOwners) MountOwner(destination string) (string, bool) {
-	return f.compoundOwner(Field_Mounts.Key(), destination)
+	return f.CompoundOwner(Field_Mounts.Key(), destination)
 }
 
 func (o *OwningPlugins) ClearMount(id, destination, plugin string) {
@@ -78,11 +78,11 @@ func (f *FieldOwners) ClaimDevice(path, plugin string) error {
 }
 
 func (o *OwningPlugins) DeviceOwner(id, path string) (string, bool) {
-	return o.ownersFor(id).compoundOwner(Field_Devices.Key(), path)
+	return o.ownersFor(id).CompoundOwner(Field_Devices.Key(), path)
 }
 
 func (f *FieldOwners) DeviceOwner(path string) (string, bool) {
-	return f.compoundOwner(Field_Devices.Key(), path)
+	return f.CompoundOwner(Field_Devices.Key(), path)
 }
 
 func (o *OwningPlugins) ClearDevice(id, path, plugin string) {
@@ -102,11 +102,11 @@ func (f *FieldOwners) ClaimCdiDevice(name, plugin string) error {
 }
 
 func (o *OwningPlugins) CdiDeviceOwner(id, name string) (string, bool) {
-	return o.ownersFor(id).compoundOwner(Field_CdiDevices.Key(), name)
+	return o.ownersFor(id).CompoundOwner(Field_CdiDevices.Key(), name)
 }
 
 func (f *FieldOwners) CdiDeviceOwner(name string) (string, bool) {
-	return f.compoundOwner(Field_CdiDevices.Key(), name)
+	return f.CompoundOwner(Field_CdiDevices.Key(), name)
 }
 
 func (o *OwningPlugins) ClearCdiDevice(id, name, plugin string) {
@@ -126,11 +126,11 @@ func (f *FieldOwners) ClaimEnv(name, plugin string) error {
 }
 
 func (o *OwningPlugins) EnvOwner(id, name string) (string, bool) {
-	return o.ownersFor(id).compoundOwner(Field_Env.Key(), name)
+	return o.ownersFor(id).CompoundOwner(Field_Env.Key(), name)
 }
 
 func (f *FieldOwners) EnvOwner(name string) (string, bool) {
-	return f.compoundOwner(Field_Env.Key(), name)
+	return f.CompoundOwner(Field_Env.Key(), name)
 }
 
 func (o *OwningPlugins) ClearEnv(id, name, plugin string) {
@@ -150,11 +150,11 @@ func (f *FieldOwners) ClaimArgs(plugin string) error {
 }
 
 func (o *OwningPlugins) ArgsOwner(id string) (string, bool) {
-	return o.ownersFor(id).simpleOwner(Field_Args.Key())
+	return o.ownersFor(id).SimpleOwner(Field_Args.Key())
 }
 
 func (f *FieldOwners) ArgsOwner() (string, bool) {
-	return f.simpleOwner(Field_Args.Key())
+	return f.SimpleOwner(Field_Args.Key())
 }
 
 func (o *OwningPlugins) ClearArgs(id, plugin string) {
@@ -174,11 +174,11 @@ func (f *FieldOwners) ClaimMemLimit(plugin string) error {
 }
 
 func (o *OwningPlugins) MemLimitOwner(id string) (string, bool) {
-	return o.ownersFor(id).simpleOwner(Field_MemLimit.Key())
+	return o.ownersFor(id).SimpleOwner(Field_MemLimit.Key())
 }
 
 func (f *FieldOwners) MemLimitOwner() (string, bool) {
-	return f.simpleOwner(Field_MemLimit.Key())
+	return f.SimpleOwner(Field_MemLimit.Key())
 }
 
 func (o *OwningPlugins) ClearMemLimit(id, plugin string) {
@@ -198,11 +198,11 @@ func (f *FieldOwners) ClaimMemReservation(plugin string) error {
 }
 
 func (o *OwningPlugins) MemReservationOwner(id string) (string, bool) {
-	return o.ownersFor(id).simpleOwner(Field_MemReservation.Key())
+	return o.ownersFor(id).SimpleOwner(Field_MemReservation.Key())
 }
 
 func (f *FieldOwners) MemReservationOwner() (string, bool) {
-	return f.simpleOwner(Field_MemReservation.Key())
+	return f.SimpleOwner(Field_MemReservation.Key())
 }
 
 func (o *OwningPlugins) ClearMemReservation(id, plugin string) {
@@ -222,11 +222,11 @@ func (f *FieldOwners) ClaimMemSwapLimit(plugin string) error {
 }
 
 func (o *OwningPlugins) MemSwapLimitOwner(id string) (string, bool) {
-	return o.ownersFor(id).simpleOwner(Field_MemSwapLimit.Key())
+	return o.ownersFor(id).SimpleOwner(Field_MemSwapLimit.Key())
 }
 
 func (f *FieldOwners) MemSwapLimitOwner() (string, bool) {
-	return f.simpleOwner(Field_MemSwapLimit.Key())
+	return f.SimpleOwner(Field_MemSwapLimit.Key())
 }
 
 func (o *OwningPlugins) ClearMemSwapLimit(id, plugin string) {
@@ -246,11 +246,11 @@ func (f *FieldOwners) ClaimMemKernelLimit(plugin string) error {
 }
 
 func (o *OwningPlugins) MemKernelLimitOwner(id string) (string, bool) {
-	return o.ownersFor(id).simpleOwner(Field_MemKernelLimit.Key())
+	return o.ownersFor(id).SimpleOwner(Field_MemKernelLimit.Key())
 }
 
 func (f *FieldOwners) MemKernelLimitOwner() (string, bool) {
-	return f.simpleOwner(Field_MemKernelLimit.Key())
+	return f.SimpleOwner(Field_MemKernelLimit.Key())
 }
 
 func (o *OwningPlugins) ClearMemKernelLimit(id, plugin string) {
@@ -270,11 +270,11 @@ func (f *FieldOwners) ClaimMemTCPLimit(plugin string) error {
 }
 
 func (o *OwningPlugins) MemTCPLimitOwner(id string) (string, bool) {
-	return o.ownersFor(id).simpleOwner(Field_MemTCPLimit.Key())
+	return o.ownersFor(id).SimpleOwner(Field_MemTCPLimit.Key())
 }
 
 func (f *FieldOwners) MemTCPLimitOwner() (string, bool) {
-	return f.simpleOwner(Field_MemTCPLimit.Key())
+	return f.SimpleOwner(Field_MemTCPLimit.Key())
 }
 
 func (o *OwningPlugins) ClearMemTCPLimit(id, plugin string) {
@@ -294,11 +294,11 @@ func (f *FieldOwners) ClaimMemSwappiness(plugin string) error {
 }
 
 func (o *OwningPlugins) MemSwappinessOwner(id string) (string, bool) {
-	return o.ownersFor(id).simpleOwner(Field_MemSwappiness.Key())
+	return o.ownersFor(id).SimpleOwner(Field_MemSwappiness.Key())
 }
 
 func (f *FieldOwners) MemSwappinessOwner() (string, bool) {
-	return f.simpleOwner(Field_MemSwappiness.Key())
+	return f.SimpleOwner(Field_MemSwappiness.Key())
 }
 
 func (o *OwningPlugins) ClearMemSwappiness(id, plugin string) {
@@ -318,11 +318,11 @@ func (f *FieldOwners) ClaimMemDisableOomKiller(plugin string) error {
 }
 
 func (o *OwningPlugins) MemDisableOomKillerOwner(id string) (string, bool) {
-	return o.ownersFor(id).simpleOwner(Field_MemDisableOomKiller.Key())
+	return o.ownersFor(id).SimpleOwner(Field_MemDisableOomKiller.Key())
 }
 
 func (f *FieldOwners) MemDisableOomKillerOwner() (string, bool) {
-	return f.simpleOwner(Field_MemDisableOomKiller.Key())
+	return f.SimpleOwner(Field_MemDisableOomKiller.Key())
 }
 
 func (o *OwningPlugins) ClearMemDisableOomKiller(id, plugin string) {
@@ -342,11 +342,11 @@ func (f *FieldOwners) ClaimMemUseHierarchy(plugin string) error {
 }
 
 func (o *OwningPlugins) MemUseHierarchyOwner(id string) (string, bool) {
-	return o.ownersFor(id).simpleOwner(Field_MemUseHierarchy.Key())
+	return o.ownersFor(id).SimpleOwner(Field_MemUseHierarchy.Key())
 }
 
 func (f *FieldOwners) MemUseHierarchyOwner() (string, bool) {
-	return f.simpleOwner(Field_MemUseHierarchy.Key())
+	return f.SimpleOwner(Field_MemUseHierarchy.Key())
 }
 
 func (o *OwningPlugins) ClearMemUseHierarchy(id, plugin string) {
@@ -366,11 +366,11 @@ func (f *FieldOwners) ClaimCPUShares(plugin string) error {
 }
 
 func (o *OwningPlugins) CPUSharesOwner(id string) (string, bool) {
-	return o.ownersFor(id).simpleOwner(Field_CPUShares.Key())
+	return o.ownersFor(id).SimpleOwner(Field_CPUShares.Key())
 }
 
 func (f *FieldOwners) CPUSharesOwner() (string, bool) {
-	return f.simpleOwner(Field_CPUShares.Key())
+	return f.SimpleOwner(Field_CPUShares.Key())
 }
 
 func (o *OwningPlugins) ClearCPUShares(id, plugin string) {
@@ -390,11 +390,11 @@ func (f *FieldOwners) ClaimCPUQuota(plugin string) error {
 }
 
 func (o *OwningPlugins) CPUQuotaOwner(id string) (string, bool) {
-	return o.ownersFor(id).simpleOwner(Field_CPUQuota.Key())
+	return o.ownersFor(id).SimpleOwner(Field_CPUQuota.Key())
 }
 
 func (f *FieldOwners) CPUQuotaOwner() (string, bool) {
-	return f.simpleOwner(Field_CPUQuota.Key())
+	return f.SimpleOwner(Field_CPUQuota.Key())
 }
 
 func (o *OwningPlugins) ClearCPUQuota(id, plugin string) {
@@ -414,11 +414,11 @@ func (f *FieldOwners) ClaimCPUPeriod(plugin string) error {
 }
 
 func (o *OwningPlugins) CPUPeriodOwner(id string) (string, bool) {
-	return o.ownersFor(id).simpleOwner(Field_CPUPeriod.Key())
+	return o.ownersFor(id).SimpleOwner(Field_CPUPeriod.Key())
 }
 
 func (f *FieldOwners) CPUPeriodOwner() (string, bool) {
-	return f.simpleOwner(Field_CPUPeriod.Key())
+	return f.SimpleOwner(Field_CPUPeriod.Key())
 }
 
 func (o *OwningPlugins) ClearCPUPeriod(id, plugin string) {
@@ -438,11 +438,11 @@ func (f *FieldOwners) ClaimCPURealtimeRuntime(plugin string) error {
 }
 
 func (o *OwningPlugins) CPURealtimeRuntimeOwner(id string) (string, bool) {
-	return o.ownersFor(id).simpleOwner(Field_CPURealtimeRuntime.Key())
+	return o.ownersFor(id).SimpleOwner(Field_CPURealtimeRuntime.Key())
 }
 
 func (f *FieldOwners) CPURealtimeRuntimeOwner() (string, bool) {
-	return f.simpleOwner(Field_CPURealtimeRuntime.Key())
+	return f.SimpleOwner(Field_CPURealtimeRuntime.Key())
 }
 
 func (o *OwningPlugins) ClearCPURealtimeRuntime(id, plugin string) {
@@ -462,11 +462,11 @@ func (f *FieldOwners) ClaimCPURealtimePeriod(plugin string) error {
 }
 
 func (o *OwningPlugins) CPURealtimePeriodOwner(id string) (string, bool) {
-	return o.ownersFor(id).simpleOwner(Field_CPURealtimePeriod.Key())
+	return o.ownersFor(id).SimpleOwner(Field_CPURealtimePeriod.Key())
 }
 
 func (f *FieldOwners) CPURealtimePeriodOwner() (string, bool) {
-	return f.simpleOwner(Field_CPURealtimePeriod.Key())
+	return f.SimpleOwner(Field_CPURealtimePeriod.Key())
 }
 
 func (o *OwningPlugins) ClearCPURealtimePeriod(id, plugin string) {
@@ -486,11 +486,11 @@ func (f *FieldOwners) ClaimCPUSetCPUs(plugin string) error {
 }
 
 func (o *OwningPlugins) CPUSetCPUsOwner(id string) (string, bool) {
-	return o.ownersFor(id).simpleOwner(Field_CPUSetCPUs.Key())
+	return o.ownersFor(id).SimpleOwner(Field_CPUSetCPUs.Key())
 }
 
 func (f *FieldOwners) CPUSetCPUsOwner() (string, bool) {
-	return f.simpleOwner(Field_CPUSetCPUs.Key())
+	return f.SimpleOwner(Field_CPUSetCPUs.Key())
 }
 
 func (o *OwningPlugins) ClearCPUSetCPUs(id, plugin string) {
@@ -510,11 +510,11 @@ func (f *FieldOwners) ClaimCPUSetMems(plugin string) error {
 }
 
 func (o *OwningPlugins) CPUSetMemsOwner(id string) (string, bool) {
-	return o.ownersFor(id).simpleOwner(Field_CPUSetMems.Key())
+	return o.ownersFor(id).SimpleOwner(Field_CPUSetMems.Key())
 }
 
 func (f *FieldOwners) CPUSetMemsOwner() (string, bool) {
-	return f.simpleOwner(Field_CPUSetMems.Key())
+	return f.SimpleOwner(Field_CPUSetMems.Key())
 }
 
 func (o *OwningPlugins) ClearCPUSetMems(id, plugin string) {
@@ -534,11 +534,11 @@ func (f *FieldOwners) ClaimPidsLimit(plugin string) error {
 }
 
 func (o *OwningPlugins) PidsLimitOwner(id string) (string, bool) {
-	return o.ownersFor(id).simpleOwner(Field_PidsLimit.Key())
+	return o.ownersFor(id).SimpleOwner(Field_PidsLimit.Key())
 }
 
 func (f *FieldOwners) PidsLimitOwner() (string, bool) {
-	return f.simpleOwner(Field_PidsLimit.Key())
+	return f.SimpleOwner(Field_PidsLimit.Key())
 }
 
 func (o *OwningPlugins) ClearPidsLimit(id, plugin string) {
@@ -558,11 +558,11 @@ func (f *FieldOwners) ClaimHugepageLimit(size, plugin string) error {
 }
 
 func (o *OwningPlugins) HugepageLimitOwner(id, size string) (string, bool) {
-	return o.ownersFor(id).compoundOwner(Field_HugepageLimits.Key(), size)
+	return o.ownersFor(id).CompoundOwner(Field_HugepageLimits.Key(), size)
 }
 
 func (f *FieldOwners) HugepageLimitOwner(size string) (string, bool) {
-	return f.compoundOwner(Field_HugepageLimits.Key(), size)
+	return f.CompoundOwner(Field_HugepageLimits.Key(), size)
 }
 
 func (o *OwningPlugins) ClearHugepageLimit(id, size, plugin string) {
@@ -582,11 +582,11 @@ func (f *FieldOwners) ClaimBlockioClass(plugin string) error {
 }
 
 func (o *OwningPlugins) BlockioClassOwner(id string) (string, bool) {
-	return o.ownersFor(id).simpleOwner(Field_BlockioClass.Key())
+	return o.ownersFor(id).SimpleOwner(Field_BlockioClass.Key())
 }
 
 func (f *FieldOwners) BlockioClassOwner() (string, bool) {
-	return f.simpleOwner(Field_BlockioClass.Key())
+	return f.SimpleOwner(Field_BlockioClass.Key())
 }
 
 func (o *OwningPlugins) ClearBlockioClass(id, plugin string) {
@@ -606,11 +606,11 @@ func (f *FieldOwners) ClaimRdtClass(plugin string) error {
 }
 
 func (o *OwningPlugins) RdtClassOwner(id string) (string, bool) {
-	return o.ownersFor(id).simpleOwner(Field_RdtClass.Key())
+	return o.ownersFor(id).SimpleOwner(Field_RdtClass.Key())
 }
 
 func (f *FieldOwners) RdtClassOwner() (string, bool) {
-	return f.simpleOwner(Field_RdtClass.Key())
+	return f.SimpleOwner(Field_RdtClass.Key())
 }
 
 func (o *OwningPlugins) ClearRdtClass(id, plugin string) {
@@ -630,11 +630,11 @@ func (f *FieldOwners) ClaimCgroupsUnified(key, plugin string) error {
 }
 
 func (o *OwningPlugins) CgroupsUnifiedOwner(id, key string) (string, bool) {
-	return o.ownersFor(id).compoundOwner(Field_CgroupsUnified.Key(), key)
+	return o.ownersFor(id).CompoundOwner(Field_CgroupsUnified.Key(), key)
 }
 
 func (f *FieldOwners) CgroupsUnifiedOwner(key string) (string, bool) {
-	return f.compoundOwner(Field_CgroupsUnified.Key(), key)
+	return f.CompoundOwner(Field_CgroupsUnified.Key(), key)
 }
 
 func (o *OwningPlugins) ClearCgroupsUnified(id, key, plugin string) {
@@ -654,11 +654,11 @@ func (f *FieldOwners) ClaimCgroupsPath(plugin string) error {
 }
 
 func (o *OwningPlugins) CgroupsPathOwner(id string) (string, bool) {
-	return o.ownersFor(id).simpleOwner(Field_CgroupsPath.Key())
+	return o.ownersFor(id).SimpleOwner(Field_CgroupsPath.Key())
 }
 
 func (f *FieldOwners) CgroupsPathOwner() (string, bool) {
-	return f.simpleOwner(Field_CgroupsPath.Key())
+	return f.SimpleOwner(Field_CgroupsPath.Key())
 }
 
 func (o *OwningPlugins) ClearCgroupsPath(id, plugin string) {
@@ -678,11 +678,11 @@ func (f *FieldOwners) ClaimOomScoreAdj(plugin string) error {
 }
 
 func (o *OwningPlugins) OomScoreAdjOwner(id string) (string, bool) {
-	return o.ownersFor(id).simpleOwner(Field_OomScoreAdj.Key())
+	return o.ownersFor(id).SimpleOwner(Field_OomScoreAdj.Key())
 }
 
 func (f *FieldOwners) OomScoreAdjOwner() (string, bool) {
-	return f.simpleOwner(Field_OomScoreAdj.Key())
+	return f.SimpleOwner(Field_OomScoreAdj.Key())
 }
 
 func (o *OwningPlugins) ClearOomScoreAdj(id, plugin string) {
@@ -702,11 +702,11 @@ func (f *FieldOwners) ClaimRlimit(typ, plugin string) error {
 }
 
 func (o *OwningPlugins) RlimitOwner(id, typ string) (string, bool) {
-	return o.ownersFor(id).compoundOwner(Field_Rlimits.Key(), typ)
+	return o.ownersFor(id).CompoundOwner(Field_Rlimits.Key(), typ)
 }
 
 func (f *FieldOwners) RlimitOwner(typ string) (string, bool) {
-	return f.compoundOwner(Field_Rlimits.Key(), typ)
+	return f.CompoundOwner(Field_Rlimits.Key(), typ)
 }
 
 func (o *OwningPlugins) ClearRlimit(id, typ, plugin string) {
@@ -726,11 +726,11 @@ func (f *FieldOwners) ClaimIOPriority(plugin string) error {
 }
 
 func (o *OwningPlugins) IOPriorityOwner(id string) (string, bool) {
-	return o.ownersFor(id).simpleOwner(Field_IoPriority.Key())
+	return o.ownersFor(id).SimpleOwner(Field_IoPriority.Key())
 }
 
 func (f *FieldOwners) IOPriorityOwner() (string, bool) {
-	return f.simpleOwner(Field_IoPriority.Key())
+	return f.SimpleOwner(Field_IoPriority.Key())
 }
 
 func (o *OwningPlugins) ClearIOPriority(id, plugin string) {
@@ -750,11 +750,11 @@ func (f *FieldOwners) ClaimSeccompPolicy(plugin string) error {
 }
 
 func (o *OwningPlugins) SeccompPolicyOwner(id string) (string, bool) {
-	return o.ownersFor(id).simpleOwner(Field_SeccompPolicy.Key())
+	return o.ownersFor(id).SimpleOwner(Field_SeccompPolicy.Key())
 }
 
 func (f *FieldOwners) SeccompPolicyOwner() (string, bool) {
-	return f.simpleOwner(Field_SeccompPolicy.Key())
+	return f.SimpleOwner(Field_SeccompPolicy.Key())
 }
 
 func (o *OwningPlugins) ClearSeccompPolicy(id, plugin string) {
@@ -774,11 +774,11 @@ func (f *FieldOwners) ClaimNamespace(typ, plugin string) error {
 }
 
 func (o *OwningPlugins) NamespaceOwner(id, typ string) (string, bool) {
-	return o.ownersFor(id).compoundOwner(Field_Namespace.Key(), typ)
+	return o.ownersFor(id).CompoundOwner(Field_Namespace.Key(), typ)
 }
 
 func (f *FieldOwners) NamespaceOwner(typ string) (string, bool) {
-	return f.compoundOwner(Field_Namespace.Key(), typ)
+	return f.CompoundOwner(Field_Namespace.Key(), typ)
 }
 
 func (o *OwningPlugins) ClearNamespace(id, typ, plugin string) {
@@ -798,11 +798,11 @@ func (f *FieldOwners) ClaimSysctl(key, plugin string) error {
 }
 
 func (o *OwningPlugins) SysctlOwner(id, key string) (string, bool) {
-	return o.ownersFor(id).compoundOwner(Field_Sysctl.Key(), key)
+	return o.ownersFor(id).CompoundOwner(Field_Sysctl.Key(), key)
 }
 
 func (f *FieldOwners) SysctlOwner(key string) (string, bool) {
-	return f.compoundOwner(Field_Sysctl.Key(), key)
+	return f.CompoundOwner(Field_Sysctl.Key(), key)
 }
 
 func (o *OwningPlugins) ClearSysctl(id, key, plugin string) {
@@ -822,11 +822,11 @@ func (f *FieldOwners) ClaimLinuxNetDevice(path, plugin string) error {
 }
 
 func (o *OwningPlugins) LinuxNetDeviceOwner(id, path string) (string, bool) {
-	return o.ownersFor(id).compoundOwner(Field_LinuxNetDevices.Key(), path)
+	return o.ownersFor(id).CompoundOwner(Field_LinuxNetDevices.Key(), path)
 }
 
 func (f *FieldOwners) LinuxNetDeviceOwner(path string) (string, bool) {
-	return f.compoundOwner(Field_LinuxNetDevices.Key(), path)
+	return f.CompoundOwner(Field_LinuxNetDevices.Key(), path)
 }
 
 func (o *OwningPlugins) ClearLinuxNetDevice(id, path, plugin string) {
@@ -846,11 +846,11 @@ func (f *FieldOwners) ClaimLinuxScheduler(plugin string) error {
 }
 
 func (o *OwningPlugins) LinuxSchedulerOwner(id string) (string, bool) {
-	return o.ownersFor(id).simpleOwner(Field_LinuxSched.Key())
+	return o.ownersFor(id).SimpleOwner(Field_LinuxSched.Key())
 }
 
 func (f *FieldOwners) LinuxSchedulerOwner() (string, bool) {
-	return f.simpleOwner(Field_LinuxSched.Key())
+	return f.SimpleOwner(Field_LinuxSched.Key())
 }
 
 func (o *OwningPlugins) ClearLinuxScheduler(id, plugin string) {
@@ -870,11 +870,11 @@ func (f *FieldOwners) ClaimRdtClosID(plugin string) error {
 }
 
 func (o *OwningPlugins) RdtClosIDOwner(id string) (string, bool) {
-	return o.ownersFor(id).simpleOwner(Field_RdtClosID.Key())
+	return o.ownersFor(id).SimpleOwner(Field_RdtClosID.Key())
 }
 
 func (f *FieldOwners) RdtClosIDOwner() (string, bool) {
-	return f.simpleOwner(Field_RdtClosID.Key())
+	return f.SimpleOwner(Field_RdtClosID.Key())
 }
 
 func (o *OwningPlugins) ClearRdtClosID(id, plugin string) {
@@ -894,11 +894,11 @@ func (f *FieldOwners) ClaimRdtSchemata(plugin string) error {
 }
 
 func (o *OwningPlugins) RdtSchemataOwner(id string) (string, bool) {
-	return o.ownersFor(id).simpleOwner(Field_RdtSchemata.Key())
+	return o.ownersFor(id).SimpleOwner(Field_RdtSchemata.Key())
 }
 
 func (f *FieldOwners) RdtSchemataOwner() (string, bool) {
-	return f.simpleOwner(Field_RdtSchemata.Key())
+	return f.SimpleOwner(Field_RdtSchemata.Key())
 }
 
 func (o *OwningPlugins) ClearRdtSchemata(id, plugin string) {
@@ -918,11 +918,11 @@ func (f *FieldOwners) ClaimRdtEnableMonitoring(plugin string) error {
 }
 
 func (o *OwningPlugins) RdtEnableMonitoringOwner(id string) (string, bool) {
-	return o.ownersFor(id).simpleOwner(Field_RdtEnableMonitoring.Key())
+	return o.ownersFor(id).SimpleOwner(Field_RdtEnableMonitoring.Key())
 }
 
 func (f *FieldOwners) RdtEnableMonitoringOwner() (string, bool) {
-	return f.simpleOwner(Field_RdtEnableMonitoring.Key())
+	return f.SimpleOwner(Field_RdtEnableMonitoring.Key())
 }
 
 func (o *OwningPlugins) ClearRdtEnableMonitoring(id, plugin string) {

--- a/pkg/runtime-tools/generate/generate.go
+++ b/pkg/runtime-tools/generate/generate.go
@@ -44,6 +44,7 @@ type UnderlyingGenerator interface {
 	AddPostStopHook(postStopHook rspec.Hook)
 	AddPreStartHook(preStartHook rspec.Hook)
 	AddProcessEnv(name, value string)
+	AddProcessRlimits(typ string, hard, soft uint64)
 	AddLinuxResourcesDevice(allow bool, devType string, major, minor *int64, access string)
 	AddLinuxResourcesHugepageLimit(pageSize string, limit uint64)
 	AddLinuxResourcesUnified(key, val string)
@@ -88,6 +89,8 @@ type Generator struct {
 	resolveRdt        func(string) (*rspec.LinuxIntelRdt, error)
 	injectCDIDevices  func(*rspec.Spec, []string) error
 	checkResources    func(*rspec.LinuxResources) error
+	logger            Logger
+	owners            *nri.FieldOwners
 }
 
 // SpecGenerator returns a wrapped OCI Spec Generator.
@@ -147,6 +150,20 @@ func WithCDIDeviceInjector(fn func(*rspec.Spec, []string) error) GeneratorOption
 		g.injectCDIDevices = fn
 	}
 }
+
+// WithLogger specifies a function for logging (audit) messages.
+func WithLogger(logger Logger, owners *nri.FieldOwners) GeneratorOption {
+	return func(g *Generator) {
+		g.logger = logger
+		g.owners = owners
+	}
+}
+
+// Fields can be used to pass extra information for logged messages.
+type Fields = map[string]any
+
+// Logger is a function for logging (audit) messages.
+type Logger = func(event string, fields Fields)
 
 // Adjust adjusts all aspects of the OCI Spec that NRI knows/cares about.
 func (g *Generator) Adjust(adjust *nri.ContainerAdjustment) error {
@@ -222,11 +239,30 @@ func (g *Generator) AdjustEnv(env []*nri.KeyValue) {
 			}
 			if m, ok := mod[keyval[0]]; ok {
 				delete(mod, keyval[0])
-				if _, marked := m.IsMarkedForRemoval(); !marked {
+				if key, marked := m.IsMarkedForRemoval(); !marked {
+					g.log(AuditAddProcessEnv,
+						Fields{
+							"value.name":  m.Key,
+							"value.value": "<value omitted>",
+							"nri.plugin":  g.compoundOwner(nri.Field_Env, m.Key),
+						},
+					)
 					g.AddProcessEnv(m.Key, m.Value)
+				} else {
+					g.log(AuditRemoveProcessEnv,
+						Fields{
+							"value.name": key,
+							"nri.plugin": g.compoundOwner(nri.Field_Env, key),
+						},
+					)
 				}
 				continue
 			}
+			g.log(AuditAddProcessEnv, Fields{
+				"value.name":  keyval[0],
+				"value.value": keyval[1],
+				"nri.plugin":  g.compoundOwner(nri.Field_Env, keyval[0]),
+			})
 			g.AddProcessEnv(keyval[0], keyval[1])
 		}
 	}
@@ -237,6 +273,11 @@ func (g *Generator) AdjustEnv(env []*nri.KeyValue) {
 			continue
 		}
 		if _, ok := mod[e.Key]; ok {
+			g.log(AuditAddProcessEnv, Fields{
+				"value.name":  e.Key,
+				"value.value": e.Value,
+				"nri.plugin":  g.compoundOwner(nri.Field_Env, e.Key),
+			})
 			g.AddProcessEnv(e.Key, e.Value)
 		}
 	}
@@ -245,6 +286,11 @@ func (g *Generator) AdjustEnv(env []*nri.KeyValue) {
 // AdjustArgs adjusts the process arguments in the OCI Spec.
 func (g *Generator) AdjustArgs(args []string) {
 	if len(args) != 0 {
+		g.log(AuditSetProcessArgs,
+			Fields{
+				"args":       strings.Join(args, " "),
+				"nri.plugin": g.simpleOwner(nri.Field_Args),
+			})
 		g.SetProcessArgs(args)
 	}
 }
@@ -258,8 +304,18 @@ func (g *Generator) AdjustAnnotations(annotations map[string]string) error {
 	}
 	for k, v := range annotations {
 		if key, marked := nri.IsMarkedForRemoval(k); marked {
-			g.RemoveAnnotation(key)
+			g.log(AuditRemoveAnnotation,
+				Fields{
+					"value.key":  key,
+					"nri.plugin": g.compoundOwner(nri.Field_Annotations, key),
+				})
 		} else {
+			g.log(AuditAddAnnotation,
+				Fields{
+					"value.key":   k,
+					"value.value": v,
+					"nri.plugin":  g.compoundOwner(nri.Field_Annotations, k),
+				})
 			g.AddAnnotation(k, v)
 		}
 	}
@@ -273,21 +329,57 @@ func (g *Generator) AdjustHooks(hooks *nri.Hooks) {
 		return
 	}
 	for _, h := range hooks.Prestart {
+		g.log(AuditAddOCIHook,
+			Fields{
+				"value.type": "PreStart",
+				"value.path": h.Path,
+				"nri.plugin": g.simpleOwner(nri.Field_OciHooks),
+			})
 		g.AddPreStartHook(h.ToOCI())
 	}
 	for _, h := range hooks.Poststart {
+		g.log(AuditAddOCIHook,
+			Fields{
+				"value.type": "PostStart",
+				"value.path": h.Path,
+				"nri.plugin": g.simpleOwner(nri.Field_OciHooks),
+			})
 		g.AddPostStartHook(h.ToOCI())
 	}
 	for _, h := range hooks.Poststop {
+		g.log(AuditAddOCIHook,
+			Fields{
+				"value.type": "PostStop",
+				"value.path": h.Path,
+				"nri.plugin": g.simpleOwner(nri.Field_OciHooks),
+			})
 		g.AddPostStopHook(h.ToOCI())
 	}
 	for _, h := range hooks.CreateRuntime {
+		g.log(AuditAddOCIHook,
+			Fields{
+				"value.type": "CreateRuntime",
+				"value.path": h.Path,
+				"nri.plugin": g.simpleOwner(nri.Field_OciHooks),
+			})
 		g.AddCreateRuntimeHook(h.ToOCI())
 	}
 	for _, h := range hooks.CreateContainer {
+		g.log(AuditAddOCIHook,
+			Fields{
+				"value.type": "CreateContainer",
+				"value.path": h.Path,
+				"nri.plugin": g.simpleOwner(nri.Field_OciHooks),
+			})
 		g.AddCreateContainerHook(h.ToOCI())
 	}
 	for _, h := range hooks.StartContainer {
+		g.log(AuditAddOCIHook,
+			Fields{
+				"value.type": "StartContainer",
+				"value.path": h.Path,
+				"nri.plugin": g.simpleOwner(nri.Field_OciHooks),
+			})
 		g.AddStartContainerHook(h.ToOCI())
 	}
 }
@@ -302,43 +394,124 @@ func (g *Generator) AdjustResources(r *nri.LinuxResources) error {
 
 	if r.Cpu != nil {
 		if r.Cpu.Period != nil {
-			g.SetLinuxResourcesCPUPeriod(r.Cpu.GetPeriod().GetValue())
+			v := r.Cpu.GetPeriod().GetValue()
+			g.log(AuditSetLinuxCPUPeriod,
+				Fields{
+					"value":      v,
+					"nri.plugin": g.simpleOwner(nri.Field_CPUPeriod),
+				})
+			g.SetLinuxResourcesCPUPeriod(v)
 		}
 		if r.Cpu.Quota != nil {
-			g.SetLinuxResourcesCPUQuota(r.Cpu.GetQuota().GetValue())
+			v := r.Cpu.GetQuota().GetValue()
+			g.log(AuditSetLinuxCPUQuota,
+				Fields{
+					"value":      v,
+					"nri.plugin": g.simpleOwner(nri.Field_CPUQuota),
+				})
+			g.SetLinuxResourcesCPUQuota(v)
 		}
 		if r.Cpu.Shares != nil {
-			g.SetLinuxResourcesCPUShares(r.Cpu.GetShares().GetValue())
+			v := r.Cpu.GetShares().GetValue()
+			g.log(AuditSetLinuxCPUShares,
+				Fields{
+					"value":      v,
+					"nri.plugin": g.simpleOwner(nri.Field_CPUShares),
+				})
+			g.SetLinuxResourcesCPUShares(v)
 		}
 		if r.Cpu.Cpus != "" {
-			g.SetLinuxResourcesCPUCpus(r.Cpu.GetCpus())
+			v := r.Cpu.GetCpus()
+			g.log(AuditSetLinuxCPUSetCPUs,
+				Fields{
+					"value":      v,
+					"nri.plugin": g.simpleOwner(nri.Field_CPUSetCPUs),
+				})
+			g.SetLinuxResourcesCPUCpus(v)
 		}
 		if r.Cpu.Mems != "" {
-			g.SetLinuxResourcesCPUMems(r.Cpu.GetMems())
+			v := r.Cpu.GetMems()
+			g.log(AuditSetLinuxCPUSetMems,
+				Fields{
+					"value":      v,
+					"nri.plugin": g.simpleOwner(nri.Field_CPUSetMems),
+				})
+			g.SetLinuxResourcesCPUMems(v)
 		}
 		if r.Cpu.RealtimeRuntime != nil {
-			g.SetLinuxResourcesCPURealtimeRuntime(r.Cpu.GetRealtimeRuntime().GetValue())
+			v := r.Cpu.GetRealtimeRuntime().GetValue()
+			g.log(AuditSetLinuxCPURealtimeRuntime,
+				Fields{
+					"value":      v,
+					"nri.plugin": g.simpleOwner(nri.Field_CPURealtimeRuntime),
+				})
+			g.SetLinuxResourcesCPURealtimeRuntime(v)
 		}
 		if r.Cpu.RealtimePeriod != nil {
-			g.SetLinuxResourcesCPURealtimePeriod(r.Cpu.GetRealtimePeriod().GetValue())
+			v := r.Cpu.GetRealtimePeriod().GetValue()
+			g.log(AuditSetLinuxCPURealtimePeriod,
+				Fields{
+					"value":      v,
+					"nri.plugin": g.simpleOwner(nri.Field_CPURealtimePeriod),
+				})
+			g.SetLinuxResourcesCPURealtimePeriod(v)
 		}
 	}
 	if r.Memory != nil {
 		if l := r.Memory.GetLimit().GetValue(); l != 0 {
+			g.log(AuditSetLinuxMemLimit,
+				Fields{
+					"value":      l,
+					"nri.plugin": g.simpleOwner(nri.Field_MemLimit),
+				})
 			g.SetLinuxResourcesMemoryLimit(l)
+			g.log(AuditSetLinuxMemSwapLimit,
+				Fields{
+					"value":      l,
+					"nri.plugin": g.simpleOwner(nri.Field_MemSwapLimit),
+				})
 			g.SetLinuxResourcesMemorySwap(l)
 		}
 	}
 	for _, l := range r.HugepageLimits {
+		g.log(AuditSetLinuxHugepageLimit,
+			Fields{
+				"value.pagesize": l.PageSize,
+				"value.limit":    l.Limit,
+				"nri.plugin":     g.compoundOwner(nri.Field_HugepageLimits, l.PageSize),
+			})
 		g.AddLinuxResourcesHugepageLimit(l.PageSize, l.Limit)
 	}
 	for k, v := range r.Unified {
+		g.log(AuditSetLinuxResourceUnified,
+			Fields{
+				"value.name":  k,
+				"value.value": v,
+				"nri.plugin":  g.compoundOwner(nri.Field_CgroupsUnified, k),
+			})
 		g.AddLinuxResourcesUnified(k, v)
 	}
 	if v := r.GetPids(); v != nil {
+		g.log(AuditSetLinuxPidsLimit,
+			Fields{
+				"value":      v.GetLimit(),
+				"nri.plugin": g.simpleOwner(nri.Field_PidsLimit),
+			})
 		g.SetLinuxResourcesPidsLimit(v.GetLimit())
 	}
+	// TODO(klihub): check this, I think it's input-only and therefore should be
+	// always empty. We don't provide an adjustment setter for it and we don't
+	// collect it during plugin response processing. If it is so, we should also
+	// check for any plugin trying to manually set it in the response and error
+	// out on the stub side if one does.
 	for _, d := range r.Devices {
+		g.log(AuditAddLinuxDeviceRule, Fields{
+			"value.allow":  d.Allow,
+			"value.type":   d.Type,
+			"value.major":  d.Major.Get(),
+			"value.minor":  d.Minor.Get(),
+			"value.access": d.Access,
+		})
 		g.AddLinuxResourcesDevice(d.Allow, d.Type, d.Major.Get(), d.Minor.Get(), d.Access)
 	}
 	if g.checkResources != nil {
@@ -357,6 +530,10 @@ func (g *Generator) AdjustBlockIOClass(blockIOClass *string) error {
 	}
 
 	if *blockIOClass == "" {
+		g.log(AuditClearLinuxBlkioClass,
+			Fields{
+				"nri.plugin": g.simpleOwner(nri.Field_BlockioClass),
+			})
 		g.ClearLinuxResourcesBlockIO()
 		return nil
 	}
@@ -366,6 +543,11 @@ func (g *Generator) AdjustBlockIOClass(blockIOClass *string) error {
 		return fmt.Errorf("failed to adjust BlockIO class in OCI Spec: %w", err)
 	}
 
+	g.log(AuditSetLinuxBlkioClass,
+		Fields{
+			"value":      *blockIOClass,
+			"nri.plugin": g.simpleOwner(nri.Field_BlockioClass),
+		})
 	g.SetLinuxResourcesBlockIO(blockIO)
 	return nil
 }
@@ -377,6 +559,10 @@ func (g *Generator) AdjustRdtClass(rdtClass *string) error {
 	}
 
 	if *rdtClass == "" {
+		g.log(AuditClearLinuxRdtClass,
+			Fields{
+				"nri.plugin": g.simpleOwner(nri.Field_RdtClass),
+			})
 		g.ClearLinuxIntelRdt()
 		return nil
 	}
@@ -386,6 +572,11 @@ func (g *Generator) AdjustRdtClass(rdtClass *string) error {
 		return fmt.Errorf("failed to adjust RDT class in OCI Spec: %w", err)
 	}
 
+	g.log(AuditSetLinuxRdtClass,
+		Fields{
+			"value":      *rdtClass,
+			"nri.plugin": g.simpleOwner(nri.Field_RdtClass),
+		})
 	g.SetLinuxIntelRdt(rdt)
 	return nil
 }
@@ -397,6 +588,7 @@ func (g *Generator) AdjustRdt(r *nri.LinuxRdt) {
 	}
 
 	if r.Remove {
+		g.log(AuditClearLinuxRdt, nil)
 		g.ClearLinuxIntelRdt()
 	}
 
@@ -408,6 +600,11 @@ func (g *Generator) AdjustRdt(r *nri.LinuxRdt) {
 // AdjustRdtClosID adjusts the RDT CLOS id in the OCI Spec.
 func (g *Generator) AdjustRdtClosID(value *string) {
 	if value != nil {
+		g.log(AuditSetLinuxRdtClosID,
+			Fields{
+				"value":      *value,
+				"nri.plugin": g.simpleOwner(nri.Field_RdtClosID),
+			})
 		g.SetLinuxIntelRdtClosID(*value)
 	}
 }
@@ -415,6 +612,11 @@ func (g *Generator) AdjustRdtClosID(value *string) {
 // AdjustRdtSchemata adjusts the RDT schemata in the OCI Spec.
 func (g *Generator) AdjustRdtSchemata(value *[]string) {
 	if value != nil {
+		g.log(AuditSetLinuxRdtSchemata,
+			Fields{
+				"value":      *value,
+				"nri.plugin": g.simpleOwner(nri.Field_RdtSchemata),
+			})
 		g.SetLinuxIntelRdtSchemata(*value)
 	}
 }
@@ -422,6 +624,11 @@ func (g *Generator) AdjustRdtSchemata(value *[]string) {
 // AdjustRdtEnableMonitoring adjusts the RDT monitoring in the OCI Spec.
 func (g *Generator) AdjustRdtEnableMonitoring(value *bool) {
 	if value != nil {
+		g.log(AuditSetLinuxRdtMonitoring,
+			Fields{
+				"value":      *value,
+				"nri.plugin": g.simpleOwner(nri.Field_RdtEnableMonitoring),
+			})
 		g.SetLinuxIntelRdtEnableMonitoring(*value)
 	}
 }
@@ -429,6 +636,11 @@ func (g *Generator) AdjustRdtEnableMonitoring(value *bool) {
 // AdjustCgroupsPath adjusts the cgroup pseudofs path in the OCI Spec.
 func (g *Generator) AdjustCgroupsPath(path string) {
 	if path != "" {
+		g.log(AuditSetLinuxCgroupsPath,
+			Fields{
+				"value":      path,
+				"nri.plugin": g.simpleOwner(nri.Field_CgroupsPath),
+			})
 		g.SetLinuxCgroupsPath(path)
 	}
 }
@@ -437,13 +649,24 @@ func (g *Generator) AdjustCgroupsPath(path string) {
 // This may override kubelet's settings for OOM score.
 func (g *Generator) AdjustOomScoreAdj(score *nri.OptionalInt) {
 	if score != nil {
-		g.SetProcessOOMScoreAdj(int(score.Value))
+		v := int(score.Value)
+		g.log(AuditSetProcessOOMScoreAdj,
+			Fields{
+				"value":      v,
+				"nri.plugin": g.simpleOwner(nri.Field_OomScoreAdj),
+			})
+		g.SetProcessOOMScoreAdj(v)
 	}
 }
 
 // AdjustIOPriority adjusts the IO priority of the container.
 func (g *Generator) AdjustIOPriority(ioprio *nri.LinuxIOPriority) {
 	if ioprio != nil {
+		g.log(AuditSetLinuxIOPriority, Fields{
+			"value.class":    ioprio.Class.String(),
+			"value.priority": ioprio.Priority,
+			"nri.plugin":     g.simpleOwner(nri.Field_IoPriority),
+		})
 		g.SetProcessIOPriority(ioprio.ToOCI())
 	}
 }
@@ -473,6 +696,10 @@ func (g *Generator) AdjustSeccompPolicy(policy *nri.LinuxSeccomp) error {
 		flags[i] = rspec.LinuxSeccompFlag(f)
 	}
 
+	g.log(AuditSetLinuxSeccompPolicy,
+		Fields{
+			"nri.plugin": g.simpleOwner(nri.Field_SeccompPolicy),
+		})
 	g.Config.Linux.Seccomp = &rspec.LinuxSeccomp{
 		DefaultAction:    rspec.LinuxSeccompAction(policy.DefaultAction),
 		Architectures:    archs,
@@ -492,10 +719,20 @@ func (g *Generator) AdjustNamespaces(namespaces []*nri.LinuxNamespace) error {
 			continue
 		}
 		if key, marked := n.IsMarkedForRemoval(); marked {
+			g.log(AuditRemoveLinuxNamespace,
+				Fields{
+					"value.type": key,
+					"nri.plugin": g.compoundOwner(nri.Field_Namespace, key),
+				})
 			if err := g.RemoveLinuxNamespace(key); err != nil {
 				return err
 			}
 		} else {
+			g.log(AuditSetLinuxNamespace, Fields{
+				"value.type": n.Type,
+				"value.path": n.Path,
+				"nri.plugin": g.compoundOwner(nri.Field_Namespace, n.Type),
+			})
 			if err := g.AddOrReplaceLinuxNamespace(n.Type, n.Path); err != nil {
 				return err
 			}
@@ -513,8 +750,19 @@ func (g *Generator) AdjustSysctl(sysctl map[string]string) error {
 	}
 	for k, v := range sysctl {
 		if key, marked := nri.IsMarkedForRemoval(k); marked {
+			g.log(AuditRemoveLinuxSysctl,
+				Fields{
+					"value.key":  key,
+					"nri.plugin": g.compoundOwner(nri.Field_Sysctl, key),
+				})
 			g.RemoveLinuxSysctl(key)
 		} else {
+			g.log(AuditSetLinuxSysctl,
+				Fields{
+					"value.key":   k,
+					"value.value": v,
+					"nri.plugin":  g.compoundOwner(nri.Field_Sysctl, k),
+				})
 			g.AddLinuxSysctl(k, v)
 		}
 	}
@@ -528,19 +776,49 @@ func (g *Generator) AdjustLinuxScheduler(sch *nri.LinuxScheduler) {
 		return
 	}
 	g.initConfigProcess()
+	g.log(AuditSetLinuxScheduler,
+		Fields{
+			"value.policy":   sch.Policy.String(),
+			"value.nice":     sch.Nice,
+			"value.priority": sch.Priority,
+			"value.runtime":  sch.Runtime,
+			"value.deadline": sch.Deadline,
+			"value.period":   sch.Period,
+			"nri.plugin":     g.simpleOwner(nri.Field_LinuxSched),
+		})
 	g.Config.Process.Scheduler = sch.ToOCI()
 }
 
 // AdjustDevices adjusts the (Linux) devices in the OCI Spec.
 func (g *Generator) AdjustDevices(devices []*nri.LinuxDevice) {
 	for _, d := range devices {
-		key, marked := d.IsMarkedForRemoval()
-		g.RemoveDevice(key)
+		path, marked := d.IsMarkedForRemoval()
+		g.log(AuditRemoveLinuxDevice,
+			Fields{
+				"value.path": path,
+				"nri.plugin": g.compoundOwner(nri.Field_Devices, path),
+			})
+		g.RemoveDevice(path)
 		if marked {
 			continue
 		}
+		g.log(AuditAddLinuxDevice, Fields{
+			"value.path":  d.Path,
+			"value.type":  d.Type,
+			"value.major": d.Major,
+			"value.minor": d.Minor,
+			"nri.plugin":  g.compoundOwner(nri.Field_Devices, d.Path),
+		})
 		g.AddDevice(d.ToOCI())
 		major, minor, access := &d.Major, &d.Minor, d.AccessString()
+		g.log(AuditAddLinuxDeviceRule, Fields{
+			"value.allow":  true,
+			"value.type":   d.Type,
+			"value.major":  d.Major,
+			"value.minor":  d.Minor,
+			"value.access": access,
+			"nri.plugin":   g.compoundOwner(nri.Field_Devices, d.Path),
+		})
 		g.AddLinuxResourcesDevice(true, d.Type, major, minor, access)
 	}
 }
@@ -549,8 +827,19 @@ func (g *Generator) AdjustDevices(devices []*nri.LinuxDevice) {
 func (g *Generator) AdjustLinuxNetDevices(devices map[string]*nri.LinuxNetDevice) error {
 	for k, v := range devices {
 		if key, marked := nri.IsMarkedForRemoval(k); marked {
+			g.log(AuditRemoveLinuxNetDevice,
+				Fields{
+					"value.hostif": key,
+					"nri.plugin":   g.compoundOwner(nri.Field_LinuxNetDevices, key),
+				})
 			g.RemoveLinuxNetDevice(key)
 		} else {
+			g.log(AuditAddLinuxNetDevice,
+				Fields{
+					"value.hostif":      k,
+					"value.containerif": v,
+					"nri.plugin":        g.compoundOwner(nri.Field_LinuxNetDevices, k),
+				})
 			g.AddLinuxNetDevice(k, v)
 		}
 	}
@@ -568,10 +857,17 @@ func (g *Generator) InjectCDIDevices(devices []*nri.CDIDevice) error {
 	}
 
 	names := []string{}
+	plugins := []string{}
 	for _, d := range devices {
 		names = append(names, d.Name)
+		plugins = append(plugins, g.compoundOwner(nri.Field_CdiDevices, d.Name))
 	}
 
+	g.log(AuditInjectCDIDevices,
+		Fields{
+			"value":      strings.Join(names, ","),
+			"nri.plugin": strings.Join(plugins, ","),
+		})
 	return g.injectCDIDevices(g.Config, names)
 }
 
@@ -581,11 +877,13 @@ func (g *Generator) AdjustRlimits(rlimits []*nri.POSIXRlimit) error {
 		if l == nil {
 			continue
 		}
-		g.Config.Process.Rlimits = append(g.Config.Process.Rlimits, rspec.POSIXRlimit{
-			Type: l.Type,
-			Hard: l.Hard,
-			Soft: l.Soft,
+		g.log(AuditAddProcessRlimits, Fields{
+			"value.type": l.Type,
+			"value.soft": l.Soft,
+			"value.hard": l.Hard,
+			"nri.plugin": g.compoundOwner(nri.Field_Rlimits, l.Type),
 		})
+		g.AddProcessRlimits(l.Type, l.Hard, l.Soft)
 	}
 	return nil
 }
@@ -599,10 +897,23 @@ func (g *Generator) AdjustMounts(mounts []*nri.Mount) error {
 	propagation := ""
 	for _, m := range mounts {
 		if destination, marked := m.IsMarkedForRemoval(); marked {
+			g.log(AuditRemoveMount,
+				Fields{
+					"value.destination": destination,
+					"nri.plugin":        g.compoundOwner(nri.Field_Mounts, destination),
+				},
+			)
 			g.RemoveMount(destination)
 			continue
 		}
 
+		plugin := g.compoundOwner(nri.Field_Mounts, m.Destination)
+		g.log(AuditRemoveMount,
+			Fields{
+				"value.destination": m.Destination,
+				"nri.plugin":        plugin,
+			},
+		)
 		g.RemoveMount(m.Destination)
 
 		mnt := m.ToOCI(&propagation)
@@ -612,6 +923,12 @@ func (g *Generator) AdjustMounts(mounts []*nri.Mount) error {
 			if err := ensurePropagation(mnt.Source, "rshared"); err != nil {
 				return fmt.Errorf("failed to adjust mounts in OCI Spec: %w", err)
 			}
+			g.log(AuditSetLinuxRootPropagation,
+				Fields{
+					"value":      "rshared",
+					"nri.plugin": plugin,
+				},
+			)
 			if err := g.SetLinuxRootPropagation("rshared"); err != nil {
 				return fmt.Errorf("failed to adjust rootfs propagation in OCI Spec: %w", err)
 			}
@@ -621,11 +938,23 @@ func (g *Generator) AdjustMounts(mounts []*nri.Mount) error {
 			}
 			rootProp := g.Config.Linux.RootfsPropagation
 			if rootProp != "rshared" && rootProp != "rslave" {
+				g.log(AuditSetLinuxRootPropagation,
+					Fields{
+						"value":      "rslave",
+						"nri.plugin": plugin,
+					})
 				if err := g.SetLinuxRootPropagation("rslave"); err != nil {
 					return fmt.Errorf("failed to adjust rootfs propagation in OCI Spec: %w", err)
 				}
 			}
 		}
+		g.log(AuditAddMount, Fields{
+			"value.destination": mnt.Destination,
+			"value.source":      mnt.Source,
+			"value.type":        mnt.Type,
+			"value.options":     strings.Join(mnt.Options, ","),
+			"nri.plugin":        plugin,
+		})
 		g.AddMount(mnt)
 	}
 	g.sortMounts()
@@ -836,3 +1165,84 @@ func (g *Generator) initConfigLinuxIntelRdt() {
 		g.Config.Linux.IntelRdt = &rspec.LinuxIntelRdt{}
 	}
 }
+
+func (g *Generator) log(event string, fields Fields) {
+	if g.logger != nil {
+		g.logger(event, fields)
+	}
+}
+
+func (g *Generator) simpleOwner(field nri.Field) string {
+	owner := "unknown"
+
+	if g.owners != nil {
+		o, _ := g.owners.SimpleOwner(field.Key())
+		if o != "" {
+			owner = o
+		}
+	}
+
+	return owner
+}
+
+func (g *Generator) compoundOwner(field nri.Field, subField string) string {
+	owner := "unknown"
+
+	if g.owners != nil {
+		o, _ := g.owners.CompoundOwner(field.Key(), subField)
+		if o != "" {
+			owner = o
+		}
+	}
+
+	return owner
+}
+
+// Audit 'events' we use in logged audit messages.
+const ( //nolint:revive
+	AuditRemoveProcessEnv           = "remove environment variable"
+	AuditAddProcessEnv              = "add environment variable"
+	AuditSetProcessArgs             = "set process arguments"
+	AuditRemoveAnnotation           = "remove annotation"
+	AuditAddAnnotation              = "add annotation"
+	AuditAddOCIHook                 = "add OCI hook"
+	AuditSetLinuxCPUPeriod          = "set linux CPU period"
+	AuditSetLinuxCPUQuota           = "set linux CPU quota"
+	AuditSetLinuxCPUShares          = "set linux CPU shares"
+	AuditSetLinuxCPUSetCPUs         = "set linux cpuset CPUs"
+	AuditSetLinuxCPUSetMems         = "set linux cpuset mems"
+	AuditSetLinuxCPURealtimeRuntime = "set linux cpu realtime runtime"
+	AuditSetLinuxCPURealtimePeriod  = "set linux cpu realtime period"
+	AuditSetLinuxMemLimit           = "set linux memory limit"
+	AuditSetLinuxMemSwapLimit       = "set linux swap limit"
+	AuditSetLinuxHugepageLimit      = "set linux hugepage limit"
+	AuditSetLinuxResourceUnified    = "set linux cgroups unified resource"
+	AuditSetLinuxPidsLimit          = "set linux PIDs limit"
+	AuditClearLinuxBlkioClass       = "clear linux blkio class"
+	AuditSetLinuxBlkioClass         = "set linux blkio class"
+	AuditClearLinuxRdtClass         = "clear linux RDT class"
+	AuditSetLinuxRdtClass           = "set linux RDT class"
+	AuditClearLinuxRdt              = "clear linux RDT"
+	AuditSetLinuxRdtClosID          = "set linux RDT CLOS ID"
+	AuditSetLinuxRdtSchemata        = "set linux RDT schemata"
+	AuditSetLinuxRdtMonitoring      = "set linux RDT monitoring"
+	AuditSetLinuxCgroupsPath        = "set linux cgroups path"
+	AuditSetProcessOOMScoreAdj      = "set process OOM score adjustment"
+	AuditSetLinuxIOPriority         = "set process IO priority"
+	AuditSetLinuxSeccompPolicy      = "set linux seccomp policy"
+	AuditRemoveLinuxNamespace       = "remove linux namespace"
+	AuditSetLinuxNamespace          = "set linux namespace"
+	AuditRemoveLinuxSysctl          = "remove linux sysctl"
+	AuditSetLinuxSysctl             = "set linux sysctl"
+	AuditSetLinuxScheduler          = "set linux scheduler"
+	AuditRemoveLinuxDevice          = "remove linux device"
+	AuditAddLinuxDevice             = "add linux device"
+	AuditAddLinuxDeviceRule         = "add linux device rule"
+	AuditRemoveLinuxNetDevice       = "remove linux net device"
+	AuditAddLinuxNetDevice          = "add linux net device"
+	AuditInjectCDIDevices           = "inject CDI devices"
+	AuditAddProcessRlimits          = "add process rlimits"
+	AuditRemoveMount                = "remove mount"
+	AuditAddMount                   = "add mount"
+	AuditSetLinuxRootPropagation    = "set linux root propagation"
+)

--- a/pkg/runtime-tools/generate/generate_suite_test.go
+++ b/pkg/runtime-tools/generate/generate_suite_test.go
@@ -17,10 +17,14 @@
 package generate_test
 
 import (
+	"bytes"
+	"fmt"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
 
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	rgen "github.com/opencontainers/runtime-tools/generate"
@@ -34,7 +38,59 @@ func TestGenerate(t *testing.T) {
 	RunSpecs(t, "Generate Suite")
 }
 
+type logger struct {
+	messages []string
+}
+
+func newLogger() *logger {
+	return &logger{
+		messages: []string{},
+	}
+}
+
+func (l *logger) Log(event string, fields xgen.Fields) {
+	var (
+		buf = &bytes.Buffer{}
+		log = &logrus.Logger{
+			Out: buf,
+			Formatter: &logrus.TextFormatter{
+				DisableTimestamp: true,
+				DisableQuote:     true,
+			},
+			Level: logrus.InfoLevel,
+		}
+	)
+	log.WithFields(fields).Info(event)
+	l.messages = append(l.messages, buf.String())
+}
+
+func (l *logger) MessageCount() int {
+	return len(l.messages)
+}
+
+func (l *logger) Has(event string, fields xgen.Fields) bool {
+	for _, entry := range l.messages {
+		if !strings.Contains(entry, event) {
+			continue
+		}
+		found := true
+		for k, v := range fields {
+			field := fmt.Sprintf("%s=%v", k, v)
+			if !strings.Contains(entry, field) {
+				found = false
+				break
+			}
+		}
+		if found {
+			return true
+		}
+	}
+	return false
+}
+
 var _ = Describe("Adjustment", func() {
+	testID := "test-ctr-id"
+
 	When("nil", func() {
 		It("does not modify the Spec", func() {
 			var (
@@ -42,12 +98,14 @@ var _ = Describe("Adjustment", func() {
 				adjust *api.ContainerAdjustment
 			)
 
+			al := newLogger()
 			rg := &rgen.Generator{Config: spec}
-			xg := xgen.SpecGenerator(rg)
+			xg := xgen.SpecGenerator(rg, xgen.WithLogger(al.Log, nil))
 
 			Expect(xg).ToNot(BeNil())
 			Expect(xg.Adjust(adjust)).To(Succeed())
 			Expect(spec).To(Equal(makeSpec()))
+			Expect(al.MessageCount()).To(Equal(0))
 		})
 	})
 
@@ -60,12 +118,14 @@ var _ = Describe("Adjustment", func() {
 				}
 			)
 
+			al := newLogger()
 			rg := &rgen.Generator{Config: spec}
-			xg := xgen.SpecGenerator(rg)
+			xg := xgen.SpecGenerator(rg, xgen.WithLogger(al.Log, nil))
 
 			Expect(xg).ToNot(BeNil())
 			Expect(xg.Adjust(adjust)).To(Succeed())
 			Expect(spec).To(Equal(makeSpec()))
+			Expect(al.MessageCount()).To(Equal(0))
 		})
 	})
 
@@ -80,14 +140,23 @@ var _ = Describe("Adjustment", func() {
 						"arg2",
 					},
 				}
+				plugin = "args-plugin"
+				owners = api.NewOwningPlugins()
 			)
 
+			owners.ClaimArgs(testID, plugin)
+
+			al := newLogger()
 			rg := &rgen.Generator{Config: spec}
-			xg := xgen.SpecGenerator(rg)
+			xg := xgen.SpecGenerator(rg, xgen.WithLogger(al.Log, owners.Owners[testID]))
 
 			Expect(xg).ToNot(BeNil())
 			Expect(xg.Adjust(adjust)).To(Succeed())
 			Expect(spec).To(Equal(makeSpec(withArgs("arg0", "arg1", "arg2"))))
+			Expect(al.Has(xgen.AuditSetProcessArgs,
+				xgen.Fields{
+					"nri.plugin": plugin,
+				})).To(BeTrue())
 		})
 	})
 
@@ -102,14 +171,26 @@ var _ = Describe("Adjustment", func() {
 						Soft: 123,
 					}},
 				}
+				plugin = "rlimits-plugin"
+				owners = api.NewOwningPlugins()
 			)
 
+			owners.ClaimRlimit(testID, "nofile", plugin)
+
+			al := newLogger()
 			rg := &rgen.Generator{Config: spec}
-			xg := xgen.SpecGenerator(rg)
+			xg := xgen.SpecGenerator(rg, xgen.WithLogger(al.Log, owners.Owners[testID]))
 
 			Expect(xg).ToNot(BeNil())
 			Expect(xg.Adjust(adjust)).To(Succeed())
 			Expect(spec).To(Equal(makeSpec(withRlimit("nofile", 456, 123))))
+			Expect(al.Has(xgen.AuditAddProcessRlimits,
+				xgen.Fields{
+					"value.type": "nofile",
+					"value.soft": 123,
+					"value.hard": 456,
+					"nri.plugin": plugin,
+				})).To(BeTrue())
 		})
 	})
 
@@ -126,14 +207,30 @@ var _ = Describe("Adjustment", func() {
 						},
 					},
 				}
+				plugin = "memlim-plugin"
+				owners = api.NewOwningPlugins()
 			)
 
+			owners.ClaimMemLimit(testID, plugin)
+			owners.ClaimMemSwapLimit(testID, plugin)
+
+			al := newLogger()
 			rg := &rgen.Generator{Config: spec}
-			xg := xgen.SpecGenerator(rg)
+			xg := xgen.SpecGenerator(rg, xgen.WithLogger(al.Log, owners.Owners[testID]))
 
 			Expect(xg).ToNot(BeNil())
 			Expect(xg.Adjust(adjust)).To(Succeed())
 			Expect(spec).To(Equal(makeSpec(withMemoryLimit(11111), withMemorySwap(11111))))
+			Expect(al.Has(xgen.AuditSetLinuxMemLimit,
+				xgen.Fields{
+					"value":      "11111",
+					"nri.plugin": plugin,
+				})).To(BeTrue())
+			Expect(al.Has(xgen.AuditSetLinuxMemSwapLimit,
+				xgen.Fields{
+					"value":      "11111",
+					"nri.plugin": plugin,
+				})).To(BeTrue())
 		})
 	})
 
@@ -149,14 +246,24 @@ var _ = Describe("Adjustment", func() {
 						},
 					},
 				}
+				plugin = "oomscoreadj-plugin"
+				owners = api.NewOwningPlugins()
 			)
 
+			owners.ClaimOomScoreAdj(testID, plugin)
+
+			al := newLogger()
 			rg := &rgen.Generator{Config: spec}
-			xg := xgen.SpecGenerator(rg)
+			xg := xgen.SpecGenerator(rg, xgen.WithLogger(al.Log, owners.Owners[testID]))
 
 			Expect(xg).ToNot(BeNil())
 			Expect(xg.Adjust(adjust)).To(Succeed())
 			Expect(spec).To(Equal(makeSpec(withOomScoreAdj(&oomScoreAdj))))
+			Expect(al.Has(xgen.AuditSetProcessOOMScoreAdj,
+				xgen.Fields{
+					"value":      oomScoreAdj,
+					"nri.plugin": plugin,
+				})).To(BeTrue())
 		})
 	})
 
@@ -171,8 +278,9 @@ var _ = Describe("Adjustment", func() {
 				}
 			)
 
+			al := newLogger()
 			rg := &rgen.Generator{Config: spec}
-			xg := xgen.SpecGenerator(rg)
+			xg := xgen.SpecGenerator(rg, xgen.WithLogger(al.Log, nil))
 
 			Expect(xg).ToNot(BeNil())
 			Expect(xg.Adjust(adjust)).To(Succeed())
@@ -191,8 +299,9 @@ var _ = Describe("Adjustment", func() {
 			spec.Process.OOMScoreAdj = &oomScoreAdj
 			expectedSpec.Process.OOMScoreAdj = &oomScoreAdj
 
+			al := newLogger()
 			rg := &rgen.Generator{Config: spec}
-			xg := xgen.SpecGenerator(rg)
+			xg := xgen.SpecGenerator(rg, xgen.WithLogger(al.Log, nil))
 
 			Expect(xg).ToNot(BeNil())
 			Expect(xg.Adjust(adjust)).To(Succeed())
@@ -213,14 +322,24 @@ var _ = Describe("Adjustment", func() {
 						},
 					},
 				}
+				plugin = "cpushares-plugin"
+				owners = api.NewOwningPlugins()
 			)
 
+			owners.ClaimCPUShares(testID, plugin)
+
+			al := newLogger()
 			rg := &rgen.Generator{Config: spec}
-			xg := xgen.SpecGenerator(rg)
+			xg := xgen.SpecGenerator(rg, xgen.WithLogger(al.Log, owners.Owners[testID]))
 
 			Expect(xg).ToNot(BeNil())
 			Expect(xg.Adjust(adjust)).To(Succeed())
 			Expect(spec).To(Equal(makeSpec(withCPUShares(11111))))
+			Expect(al.Has(xgen.AuditSetLinuxCPUShares,
+				xgen.Fields{
+					"value":      11111,
+					"nri.plugin": plugin,
+				})).To(BeTrue())
 		})
 	})
 
@@ -237,14 +356,24 @@ var _ = Describe("Adjustment", func() {
 						},
 					},
 				}
+				plugin = "cpuquota-plugin"
+				owners = api.NewOwningPlugins()
 			)
 
+			owners.ClaimCPUQuota(testID, plugin)
+
+			al := newLogger()
 			rg := &rgen.Generator{Config: spec}
-			xg := xgen.SpecGenerator(rg)
+			xg := xgen.SpecGenerator(rg, xgen.WithLogger(al.Log, owners.Owners[testID]))
 
 			Expect(xg).ToNot(BeNil())
 			Expect(xg.Adjust(adjust)).To(Succeed())
 			Expect(spec).To(Equal(makeSpec(withCPUQuota(11111))))
+			Expect(al.Has(xgen.AuditSetLinuxCPUQuota,
+				xgen.Fields{
+					"value":      11111,
+					"nri.plugin": plugin,
+				})).To(BeTrue())
 		})
 	})
 
@@ -261,14 +390,24 @@ var _ = Describe("Adjustment", func() {
 						},
 					},
 				}
+				plugin = "cpuperiod-plugin"
+				owners = api.NewOwningPlugins()
 			)
 
+			owners.ClaimCPUPeriod(testID, plugin)
+
+			al := newLogger()
 			rg := &rgen.Generator{Config: spec}
-			xg := xgen.SpecGenerator(rg)
+			xg := xgen.SpecGenerator(rg, xgen.WithLogger(al.Log, owners.Owners[testID]))
 
 			Expect(xg).ToNot(BeNil())
 			Expect(xg.Adjust(adjust)).To(Succeed())
 			Expect(spec).To(Equal(makeSpec(withCPUPeriod(11111))))
+			Expect(al.Has(xgen.AuditSetLinuxCPUPeriod,
+				xgen.Fields{
+					"value":      11111,
+					"nri.plugin": plugin,
+				})).To(BeTrue())
 		})
 	})
 
@@ -285,14 +424,24 @@ var _ = Describe("Adjustment", func() {
 						},
 					},
 				}
+				plugin = "cpuset-plugin"
+				owners = api.NewOwningPlugins()
 			)
 
+			owners.ClaimCPUSetCPUs(testID, plugin)
+
+			al := newLogger()
 			rg := &rgen.Generator{Config: spec}
-			xg := xgen.SpecGenerator(rg)
+			xg := xgen.SpecGenerator(rg, xgen.WithLogger(al.Log, owners.Owners[testID]))
 
 			Expect(xg).ToNot(BeNil())
 			Expect(xg.Adjust(adjust)).To(Succeed())
 			Expect(spec).To(Equal(makeSpec(withCPUSetCPUs("5,6"))))
+			Expect(al.Has(xgen.AuditSetLinuxCPUSetCPUs,
+				xgen.Fields{
+					"value":      "5,6",
+					"nri.plugin": plugin,
+				})).To(BeTrue())
 		})
 	})
 
@@ -309,14 +458,24 @@ var _ = Describe("Adjustment", func() {
 						},
 					},
 				}
+				plugin = "memset-plugin"
+				owners = api.NewOwningPlugins()
 			)
 
+			owners.ClaimCPUSetMems(testID, plugin)
+
+			al := newLogger()
 			rg := &rgen.Generator{Config: spec}
-			xg := xgen.SpecGenerator(rg)
+			xg := xgen.SpecGenerator(rg, xgen.WithLogger(al.Log, owners.Owners[testID]))
 
 			Expect(xg).ToNot(BeNil())
 			Expect(xg.Adjust(adjust)).To(Succeed())
 			Expect(spec).To(Equal(makeSpec(withCPUSetMems("5,6"))))
+			Expect(al.Has(xgen.AuditSetLinuxCPUSetMems,
+				xgen.Fields{
+					"value":      "5,6",
+					"nri.plugin": plugin,
+				})).To(BeTrue())
 		})
 	})
 
@@ -333,14 +492,23 @@ var _ = Describe("Adjustment", func() {
 						},
 					},
 				}
+				owners = api.NewOwningPlugins()
 			)
 
+			// leave unclaimed to test "unknown" plugin
+
+			al := newLogger()
 			rg := &rgen.Generator{Config: spec}
-			xg := xgen.SpecGenerator(rg)
+			xg := xgen.SpecGenerator(rg, xgen.WithLogger(al.Log, owners.Owners[testID]))
 
 			Expect(xg).ToNot(BeNil())
 			Expect(xg.Adjust(adjust)).To(Succeed())
 			Expect(spec).To(Equal(makeSpec(withPidsLimit(123))))
+			Expect(al.Has(xgen.AuditSetLinuxPidsLimit,
+				xgen.Fields{
+					"value":      123,
+					"nri.plugin": "unknown",
+				})).To(BeTrue())
 		})
 	})
 
@@ -368,10 +536,18 @@ var _ = Describe("Adjustment", func() {
 						},
 					},
 				}
+				plugin = "mount-plugin"
+				owners = api.NewOwningPlugins()
 			)
 
+			owners.ClaimMount(testID, adjust.Mounts[0].Destination, plugin)
+			owners.ClaimMount(testID, adjust.Mounts[1].Destination, plugin)
+			owners.ClaimMount(testID, adjust.Mounts[2].Destination, plugin)
+			owners.ClaimMount(testID, adjust.Mounts[3].Destination, plugin)
+
+			al := newLogger()
 			rg := &rgen.Generator{Config: spec}
-			xg := xgen.SpecGenerator(rg)
+			xg := xgen.SpecGenerator(rg, xgen.WithLogger(al.Log, owners.Owners[testID]))
 
 			Expect(xg).ToNot(BeNil())
 			Expect(xg.Adjust(adjust)).To(Succeed())
@@ -395,6 +571,26 @@ var _ = Describe("Adjustment", func() {
 					},
 				}),
 			)))
+			Expect(al.Has(xgen.AuditAddMount,
+				xgen.Fields{
+					"value.destination": "/a",
+					"nri.plugin":        plugin,
+				})).To(BeTrue())
+			Expect(al.Has(xgen.AuditAddMount,
+				xgen.Fields{
+					"value.destination": "/a/b",
+					"nri.plugin":        plugin,
+				})).To(BeTrue())
+			Expect(al.Has(xgen.AuditAddMount,
+				xgen.Fields{
+					"value.destination": "/a/b/c",
+					"nri.plugin":        plugin,
+				})).To(BeTrue())
+			Expect(al.Has(xgen.AuditAddMount,
+				xgen.Fields{
+					"value.destination": "/a/b/c/d/e",
+					"nri.plugin":        plugin,
+				})).To(BeTrue())
 		})
 	})
 
@@ -418,14 +614,23 @@ var _ = Describe("Adjustment", func() {
 						SeccompPolicy: api.FromOCILinuxSeccomp(&seccomp),
 					},
 				}
+				plugin = "seccomp-plugin"
+				owners = api.NewOwningPlugins()
 			)
 
+			owners.ClaimSeccompPolicy(testID, plugin)
+
+			al := newLogger()
 			rg := &rgen.Generator{Config: spec}
-			xg := xgen.SpecGenerator(rg)
+			xg := xgen.SpecGenerator(rg, xgen.WithLogger(al.Log, owners.Owners[testID]))
 
 			Expect(xg).ToNot(BeNil())
 			Expect(xg.Adjust(adjust)).To(Succeed())
 			Expect(*spec.Linux.Seccomp).To(Equal(seccomp))
+			Expect(al.Has(xgen.AuditSetLinuxSeccompPolicy,
+				xgen.Fields{
+					"nri.plugin": plugin,
+				})).To(BeTrue())
 		})
 	})
 
@@ -441,19 +646,31 @@ var _ = Describe("Adjustment", func() {
 						},
 					},
 				}
+				plugin = "sysctl-plugin"
+				owners = api.NewOwningPlugins()
 			)
+
+			owners.ClaimSysctl(testID, "net.ipv4.ip_forward", plugin)
+
 			spec.Linux.Sysctl = map[string]string{
 				"delete.me": "foobar",
 			}
+
+			al := newLogger()
 			rg := &rgen.Generator{Config: spec}
-			xg := xgen.SpecGenerator(rg)
+			xg := xgen.SpecGenerator(rg, xgen.WithLogger(al.Log, owners.Owners[testID]))
 
 			Expect(xg).ToNot(BeNil())
 			Expect(xg.Adjust(adjust)).To(Succeed())
 			Expect(spec.Linux.Sysctl).To(Equal(map[string]string{
 				"net.ipv4.ip_forward": "1",
 			}))
-
+			Expect(al.Has(xgen.AuditSetLinuxSysctl,
+				xgen.Fields{
+					"value.key":   "net.ipv4.ip_forward",
+					"value.value": "1",
+					"nri.plugin":  plugin,
+				})).To(BeTrue())
 		})
 	})
 
@@ -469,9 +686,16 @@ var _ = Describe("Adjustment", func() {
 					},
 				},
 			}
+			plugin := "rdt-plugin"
+			owners := api.NewOwningPlugins()
 
+			owners.ClaimRdtClosID(testID, "rdt-plugin")
+			owners.ClaimRdtSchemata(testID, "rdt-plugin")
+			owners.ClaimRdtEnableMonitoring(testID, "rdt-plugin")
+
+			al := newLogger()
 			rg := &rgen.Generator{Config: spec}
-			xg := xgen.SpecGenerator(rg)
+			xg := xgen.SpecGenerator(rg, xgen.WithLogger(al.Log, owners.Owners[testID]))
 
 			Expect(xg).ToNot(BeNil())
 			Expect(xg.Adjust(adjust)).To(Succeed())
@@ -480,6 +704,21 @@ var _ = Describe("Adjustment", func() {
 				Schemata:         []string{"L2:0=ff", "L3:0=f"},
 				EnableMonitoring: true,
 			}))
+			Expect(al.Has(xgen.AuditSetLinuxRdtClosID,
+				xgen.Fields{
+					"value":      "foo",
+					"nri.plugin": plugin,
+				})).To(BeTrue())
+			Expect(al.Has(xgen.AuditSetLinuxRdtSchemata,
+				xgen.Fields{
+					"value":      "[L2:0=ff L3:0=f]",
+					"nri.plugin": plugin,
+				})).To(BeTrue())
+			Expect(al.Has(xgen.AuditSetLinuxRdtMonitoring,
+				xgen.Fields{
+					"value":      true,
+					"nri.plugin": plugin,
+				})).To(BeTrue())
 		})
 	})
 	When("has a RDT remove adjustment", func() {
@@ -494,12 +733,14 @@ var _ = Describe("Adjustment", func() {
 				},
 			}
 
+			al := newLogger()
 			rg := &rgen.Generator{Config: spec}
-			xg := xgen.SpecGenerator(rg)
+			xg := xgen.SpecGenerator(rg, xgen.WithLogger(al.Log, nil))
 
 			Expect(xg).ToNot(BeNil())
 			Expect(xg.Adjust(adjust)).To(Succeed())
 			Expect(spec.Linux.IntelRdt).To(BeNil())
+			Expect(al.Has(xgen.AuditClearLinuxRdt, nil)).To(BeTrue())
 		})
 	})
 })

--- a/tools/protoc-gen-owners/main.go
+++ b/tools/protoc-gen-owners/main.go
@@ -173,13 +173,13 @@ func generateOwnerFuncs(g *protogen.GeneratedFile, fieldEnum *protogen.Enum) {
 
 			// OwningPlugins.<Field>Owner
 			g.P("func (o *OwningPlugins) ", fieldName, "Owner(id, ", keyName, " string) (string, bool) {")
-			g.P("    return o.ownersFor(id).compoundOwner(Field_", originalFieldName, ".Key(), ", keyName, ")")
+			g.P("    return o.ownersFor(id).CompoundOwner(Field_", originalFieldName, ".Key(), ", keyName, ")")
 			g.P("}")
 			g.P()
 
 			// FieldOwners.<Field>Owner
 			g.P("func (f *FieldOwners) ", fieldName, "Owner(", keyName, " string) (string, bool) {")
-			g.P("    return f.compoundOwner(Field_", originalFieldName, ".Key(), ", keyName, ")")
+			g.P("    return f.CompoundOwner(Field_", originalFieldName, ".Key(), ", keyName, ")")
 			g.P("}")
 			g.P()
 
@@ -209,13 +209,13 @@ func generateOwnerFuncs(g *protogen.GeneratedFile, fieldEnum *protogen.Enum) {
 
 			// OwningPlugins.<Field>Owner
 			g.P("func (o *OwningPlugins) ", fieldName, "Owner(id string) (string, bool) {")
-			g.P("    return o.ownersFor(id).simpleOwner(Field_", originalFieldName, ".Key())")
+			g.P("    return o.ownersFor(id).SimpleOwner(Field_", originalFieldName, ".Key())")
 			g.P("}")
 			g.P()
 
 			// FieldOwners.<Field>Owner
 			g.P("func (f *FieldOwners) ", fieldName, "Owner() (string, bool) {")
-			g.P("    return f.simpleOwner(Field_", originalFieldName, ".Key())")
+			g.P("    return f.SimpleOwner(Field_", originalFieldName, ".Key())")
 			g.P("}")
 			g.P()
 


### PR DESCRIPTION
This PR implements NRI audit logging for OCI Spec adjustments, which has been identified as one of the missing things we need to add (be)for(e) a v1.0. This patch
- adds an extended generator option for runtimes to set an external audit event logger, and
- updates the generator to use the configured logger for audit messages when an OCI Spec is adjusted

Here are updated trees for contained and CRI-O:
- [containerd](https://github.com/klihub/containerd/commits/devel/main/nri-audit-logging)
- [cri-o](https://github.com/klihub/cri-o/commits/devel/main/nri-audit-logging)