### PR TITLE
add basic metrics for NRI framework

### DIFF
--- a/pkg/adaptation/adaptation.go
+++ b/pkg/adaptation/adaptation.go
@@ -75,6 +75,7 @@ type Adaptation struct {
 	builtin     []*builtin.BuiltinPlugin
 	syncLock    sync.RWMutex
 	wasmService *api.PluginPlugin
+	metrics     Metrics
 }
 
 var (
@@ -137,6 +138,16 @@ func WithBuiltinPlugins(plugins ...*builtin.BuiltinPlugin) Option {
 	}
 }
 
+// WithMetrics allows consumers to register an implementation of the Metrics interface.
+func WithMetrics(m Metrics) Option {
+	return func(r *Adaptation) error {
+		if m != nil {
+			r.metrics = m
+		}
+		return nil
+	}
+}
+
 // WithDefaultValidator sets up builtin validator plugin if it is configured.
 func WithDefaultValidator(cfg *validator.DefaultValidatorConfig) Option {
 	return func(r *Adaptation) error {
@@ -177,6 +188,7 @@ func New(name, version string, syncFn SyncFn, updateFn UpdateFn, opts ...Option)
 		socketPath:  DefaultSocketPath,
 		syncLock:    sync.RWMutex{},
 		wasmService: wasmService,
+		metrics:     &noopMetrics{},
 	}
 
 	for _, o := range opts {
@@ -540,6 +552,7 @@ func (r *Adaptation) removeClosedPlugins() {
 
 	r.plugins = active
 	r.validators = validators
+	r.metrics.UpdatePluginCount(len(r.plugins))
 }
 
 func (r *Adaptation) startListener() error {
@@ -607,7 +620,9 @@ func (r *Adaptation) acceptPluginConnections(l net.Listener) error {
 					r.validators = append(r.validators, p)
 				}
 				r.sortPlugins()
+				count := len(r.plugins)
 				r.Unlock()
+				r.metrics.UpdatePluginCount(count)
 				log.Infof(ctx, "plugin %q connected and synchronized", p.name())
 			}
 			r.finishedPluginSync()

--- a/pkg/adaptation/metrics.go
+++ b/pkg/adaptation/metrics.go
@@ -1,0 +1,47 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package adaptation
+
+import "time"
+
+// Metrics defines the interface that a consumer can implement to collect
+// and emit metrics regarding NRI plugin activity.
+// Implementations of this interface must be thread-safe, as these methods
+// are invoked concurrently across multiple goroutines handling plugin requests.
+type Metrics interface {
+	// RecordPluginInvocation records the invocation of a plugin for a specific operation.
+	RecordPluginInvocation(pluginName, operation string, err error)
+
+	// RecordPluginLatency records the latency of a plugin invocation.
+	RecordPluginLatency(pluginName, operation string, latency time.Duration)
+
+	// RecordPluginAdjustments records the adjustments returned by a plugin.
+	RecordPluginAdjustments(pluginName, operation string, adjust *ContainerAdjustment, updates, evicts int)
+
+	// UpdatePluginCount sets the number of currently active plugins.
+	UpdatePluginCount(count int)
+}
+
+// noopMetrics provides a default, no-operation implementation of the Metrics interface.
+type noopMetrics struct{}
+
+var _ Metrics = (*noopMetrics)(nil)
+
+func (n *noopMetrics) RecordPluginInvocation(_, _ string, _ error)                           {}
+func (n *noopMetrics) RecordPluginLatency(_, _ string, _ time.Duration)                      {}
+func (n *noopMetrics) RecordPluginAdjustments(_, _ string, _ *ContainerAdjustment, _, _ int) {}
+func (n *noopMetrics) UpdatePluginCount(_ int)                                               {}

--- a/pkg/adaptation/metrics_test.go
+++ b/pkg/adaptation/metrics_test.go
@@ -1,0 +1,324 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package adaptation
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/containerd/nri/pkg/api"
+	"github.com/stretchr/testify/assert"
+)
+
+// mockMetrics provides a simple implementation of the Metrics interface for testing.
+type mockMetrics struct {
+	pluginCount int
+	invocations []mockInvocation
+	latencies   []mockLatency
+	adjustments []mockAdjustment
+}
+
+type mockInvocation struct {
+	pluginName string
+	operation  string
+	err        error
+}
+
+type mockLatency struct {
+	pluginName string
+	operation  string
+	latency    time.Duration
+}
+
+type mockAdjustment struct {
+	pluginName string
+	operation  string
+	adjust     *ContainerAdjustment
+	updates    int
+	evicts     int
+}
+
+func (m *mockMetrics) RecordPluginInvocation(pluginName, operation string, err error) {
+	m.invocations = append(m.invocations, mockInvocation{
+		pluginName: pluginName,
+		operation:  operation,
+		err:        err,
+	})
+}
+
+func (m *mockMetrics) RecordPluginLatency(pluginName, operation string, latency time.Duration) {
+	m.latencies = append(m.latencies, mockLatency{
+		pluginName: pluginName,
+		operation:  operation,
+		latency:    latency,
+	})
+}
+
+func (m *mockMetrics) RecordPluginAdjustments(pluginName, operation string, adjust *ContainerAdjustment, updates, evicts int) {
+	m.adjustments = append(m.adjustments, mockAdjustment{
+		pluginName: pluginName,
+		operation:  operation,
+		adjust:     adjust,
+		updates:    updates,
+		evicts:     evicts,
+	})
+}
+
+func (m *mockMetrics) UpdatePluginCount(count int) {
+	m.pluginCount = count
+}
+
+type dummyPlugin struct {
+	api.PluginService
+}
+
+func (d *dummyPlugin) Synchronize(_ context.Context, _ *api.SynchronizeRequest) (*api.SynchronizeResponse, error) {
+	return &api.SynchronizeResponse{
+		Update: []*api.ContainerUpdate{
+			{ContainerId: "test-container"},
+		},
+	}, nil
+}
+
+func (d *dummyPlugin) CreateContainer(_ context.Context, _ *api.CreateContainerRequest) (*api.CreateContainerResponse, error) {
+	return &api.CreateContainerResponse{
+		Adjust: &api.ContainerAdjustment{},
+		Update: []*api.ContainerUpdate{
+			{ContainerId: "test-container"},
+		},
+		Evict: []*api.ContainerEviction{
+			{ContainerId: "test-container"},
+		},
+	}, nil
+}
+
+func (d *dummyPlugin) UpdateContainer(_ context.Context, _ *api.UpdateContainerRequest) (*api.UpdateContainerResponse, error) {
+	return &api.UpdateContainerResponse{
+		Update: []*api.ContainerUpdate{
+			{ContainerId: "test-container"},
+		},
+		Evict: []*api.ContainerEviction{
+			{ContainerId: "test-container"},
+			{ContainerId: "test-container-2"},
+		},
+	}, nil
+}
+
+func (d *dummyPlugin) StopContainer(_ context.Context, _ *api.StopContainerRequest) (*api.StopContainerResponse, error) {
+	return &api.StopContainerResponse{
+		Update: []*api.ContainerUpdate{
+			{ContainerId: "test-container"},
+		},
+	}, nil
+}
+
+func (d *dummyPlugin) UpdatePodSandbox(_ context.Context, _ *api.UpdatePodSandboxRequest) (*api.UpdatePodSandboxResponse, error) {
+	return &api.UpdatePodSandboxResponse{}, nil
+}
+
+func (d *dummyPlugin) StateChange(_ context.Context, _ *api.StateChangeEvent) (*api.Empty, error) {
+	return &api.Empty{}, nil
+}
+
+func (d *dummyPlugin) ValidateContainerAdjustment(_ context.Context, _ *api.ValidateContainerAdjustmentRequest) (*api.ValidateContainerAdjustmentResponse, error) {
+	return &api.ValidateContainerAdjustmentResponse{}, nil
+}
+
+func setupTestPlugin() (*mockMetrics, *plugin) {
+	m := &mockMetrics{}
+	adapt := &Adaptation{metrics: m}
+
+	impl := &pluginType{builtinImpl: &dummyPlugin{}}
+
+	var events api.EventMask
+	events.Set(api.Event_CREATE_CONTAINER)
+	events.Set(api.Event_UPDATE_CONTAINER)
+	events.Set(api.Event_STOP_CONTAINER)
+	events.Set(api.Event_UPDATE_POD_SANDBOX)
+	events.Set(api.Event_VALIDATE_CONTAINER_ADJUSTMENT)
+
+	p := &plugin{
+		r:      adapt,
+		events: events,
+		impl:   impl,
+		idx:    "00",
+		base:   "test-plugin",
+	}
+
+	return m, p
+}
+
+func TestPluginSynchronizeMetrics(t *testing.T) {
+	m, p := setupTestPlugin()
+
+	_, err := p.synchronize(context.Background(), nil, nil)
+	assert.NoError(t, err)
+
+	assert.Len(t, m.invocations, 1)
+	assert.Equal(t, "00-test-plugin", m.invocations[0].pluginName)
+	assert.Equal(t, "Synchronize", m.invocations[0].operation)
+	assert.Nil(t, m.invocations[0].err)
+
+	assert.Len(t, m.latencies, 1)
+	assert.Equal(t, "00-test-plugin", m.latencies[0].pluginName)
+	assert.Equal(t, "Synchronize", m.latencies[0].operation)
+	assert.NotZero(t, m.latencies[0].latency)
+
+	assert.Len(t, m.adjustments, 1)
+	assert.Equal(t, "00-test-plugin", m.adjustments[0].pluginName)
+	assert.Equal(t, "Synchronize", m.adjustments[0].operation)
+	assert.Equal(t, 1, m.adjustments[0].updates)
+	assert.Equal(t, 0, m.adjustments[0].evicts)
+	assert.Nil(t, m.adjustments[0].adjust)
+}
+
+func TestPluginCreateContainerMetrics(t *testing.T) {
+	m, p := setupTestPlugin()
+
+	req := &api.CreateContainerRequest{}
+	_, err := p.createContainer(context.Background(), req)
+	assert.NoError(t, err)
+
+	assert.Len(t, m.invocations, 1)
+	assert.Equal(t, "00-test-plugin", m.invocations[0].pluginName)
+	assert.Equal(t, "CreateContainer", m.invocations[0].operation)
+	assert.Nil(t, m.invocations[0].err)
+
+	assert.Len(t, m.latencies, 1)
+	assert.Equal(t, "00-test-plugin", m.latencies[0].pluginName)
+	assert.Equal(t, "CreateContainer", m.latencies[0].operation)
+	assert.NotZero(t, m.latencies[0].latency)
+
+	assert.Len(t, m.adjustments, 1)
+	assert.Equal(t, "00-test-plugin", m.adjustments[0].pluginName)
+	assert.Equal(t, "CreateContainer", m.adjustments[0].operation)
+	assert.Equal(t, 1, m.adjustments[0].updates)
+	assert.Equal(t, 1, m.adjustments[0].evicts)
+	assert.NotNil(t, m.adjustments[0].adjust)
+}
+
+func TestPluginUpdateContainerMetrics(t *testing.T) {
+	m, p := setupTestPlugin()
+
+	req := &api.UpdateContainerRequest{}
+	_, err := p.updateContainer(context.Background(), req)
+	assert.NoError(t, err)
+
+	assert.Len(t, m.invocations, 1)
+	assert.Equal(t, "00-test-plugin", m.invocations[0].pluginName)
+	assert.Equal(t, "UpdateContainer", m.invocations[0].operation)
+	assert.Nil(t, m.invocations[0].err)
+
+	assert.Len(t, m.latencies, 1)
+	assert.Equal(t, "00-test-plugin", m.latencies[0].pluginName)
+	assert.Equal(t, "UpdateContainer", m.latencies[0].operation)
+	assert.NotZero(t, m.latencies[0].latency)
+
+	assert.Len(t, m.adjustments, 1)
+	assert.Equal(t, "00-test-plugin", m.adjustments[0].pluginName)
+	assert.Equal(t, "UpdateContainer", m.adjustments[0].operation)
+	assert.Equal(t, 1, m.adjustments[0].updates)
+	assert.Equal(t, 2, m.adjustments[0].evicts)
+	assert.Nil(t, m.adjustments[0].adjust)
+}
+
+func TestPluginStopContainerMetrics(t *testing.T) {
+	m, p := setupTestPlugin()
+
+	req := &api.StopContainerRequest{}
+	_, err := p.stopContainer(context.Background(), req)
+	assert.NoError(t, err)
+
+	assert.Len(t, m.invocations, 1)
+	assert.Equal(t, "00-test-plugin", m.invocations[0].pluginName)
+	assert.Equal(t, "StopContainer", m.invocations[0].operation)
+	assert.Nil(t, m.invocations[0].err)
+
+	assert.Len(t, m.latencies, 1)
+	assert.Equal(t, "00-test-plugin", m.latencies[0].pluginName)
+	assert.Equal(t, "StopContainer", m.latencies[0].operation)
+	assert.NotZero(t, m.latencies[0].latency)
+
+	assert.Len(t, m.adjustments, 1)
+	assert.Equal(t, "00-test-plugin", m.adjustments[0].pluginName)
+	assert.Equal(t, "StopContainer", m.adjustments[0].operation)
+	assert.Equal(t, 1, m.adjustments[0].updates)
+	assert.Equal(t, 0, m.adjustments[0].evicts)
+	assert.Nil(t, m.adjustments[0].adjust)
+}
+
+func TestPluginUpdatePodSandboxMetrics(t *testing.T) {
+	m, p := setupTestPlugin()
+
+	req := &api.UpdatePodSandboxRequest{}
+	_, err := p.updatePodSandbox(context.Background(), req)
+	assert.NoError(t, err)
+
+	assert.Len(t, m.invocations, 1)
+	assert.Equal(t, "00-test-plugin", m.invocations[0].pluginName)
+	assert.Equal(t, "UpdatePodSandbox", m.invocations[0].operation)
+	assert.Nil(t, m.invocations[0].err)
+
+	assert.Len(t, m.latencies, 1)
+	assert.Equal(t, "00-test-plugin", m.latencies[0].pluginName)
+	assert.Equal(t, "UpdatePodSandbox", m.latencies[0].operation)
+	assert.NotZero(t, m.latencies[0].latency)
+
+	assert.Len(t, m.adjustments, 0)
+}
+
+func TestPluginStateChangeMetrics(t *testing.T) {
+	m, p := setupTestPlugin()
+
+	evt := &api.StateChangeEvent{
+		Event: api.Event_CREATE_CONTAINER,
+	}
+
+	err := p.StateChange(context.Background(), evt)
+	assert.NoError(t, err)
+
+	assert.Len(t, m.invocations, 1)
+	assert.Equal(t, "00-test-plugin", m.invocations[0].pluginName)
+	assert.Equal(t, "StateChange/CreateContainer", m.invocations[0].operation)
+	assert.Nil(t, m.invocations[0].err)
+
+	assert.Len(t, m.latencies, 1)
+	assert.Equal(t, "00-test-plugin", m.latencies[0].pluginName)
+	assert.Equal(t, "StateChange/CreateContainer", m.latencies[0].operation)
+	assert.NotZero(t, m.latencies[0].latency)
+}
+
+func TestPluginValidateContainerAdjustmentMetrics(t *testing.T) {
+	m, p := setupTestPlugin()
+
+	req := &api.ValidateContainerAdjustmentRequest{}
+	err := p.ValidateContainerAdjustment(context.Background(), req)
+	assert.NoError(t, err)
+
+	assert.Len(t, m.invocations, 1)
+	assert.Equal(t, "00-test-plugin", m.invocations[0].pluginName)
+	assert.Equal(t, "ValidateContainerAdjustment", m.invocations[0].operation)
+	assert.Nil(t, m.invocations[0].err)
+
+	assert.Len(t, m.latencies, 1)
+	assert.Equal(t, "00-test-plugin", m.latencies[0].pluginName)
+	assert.Equal(t, "ValidateContainerAdjustment", m.latencies[0].operation)
+	assert.NotZero(t, m.latencies[0].latency)
+
+	assert.Len(t, m.adjustments, 0)
+}

--- a/pkg/adaptation/plugin.go
+++ b/pkg/adaptation/plugin.go
@@ -527,8 +527,14 @@ func (p *plugin) synchronize(ctx context.Context, pods []*PodSandbox, containers
 		log.Debugf(ctx, "sending sync message, %d/%d, %d/%d (more: %v)",
 			len(req.Pods), len(podsToSend), len(req.Containers), len(ctrsToSend), req.More)
 
+		start := time.Now()
 		rpl, err = p.impl.Synchronize(ctx, req)
+		p.r.metrics.RecordPluginLatency(p.name(), "Synchronize", time.Since(start))
+		p.r.metrics.RecordPluginInvocation(p.name(), "Synchronize", err)
 		if err == nil {
+			if rpl != nil {
+				p.r.metrics.RecordPluginAdjustments(p.name(), "Synchronize", nil, len(rpl.Update), 0)
+			}
 			if !req.More {
 				break
 			}
@@ -611,7 +617,10 @@ func (p *plugin) createContainer(ctx context.Context, req *CreateContainerReques
 	ctx, cancel := context.WithTimeout(ctx, getPluginRequestTimeout())
 	defer cancel()
 
+	start := time.Now()
 	rpl, err := p.impl.CreateContainer(ctx, req)
+	p.r.metrics.RecordPluginLatency(p.name(), "CreateContainer", time.Since(start))
+	p.r.metrics.RecordPluginInvocation(p.name(), "CreateContainer", err)
 	if err != nil {
 		if isFatalError(err) {
 			log.Errorf(ctx, "closing plugin %s, failed to handle CreateContainer request: %v",
@@ -620,6 +629,9 @@ func (p *plugin) createContainer(ctx context.Context, req *CreateContainerReques
 			return nil, nil
 		}
 		return nil, err
+	}
+	if rpl != nil {
+		p.r.metrics.RecordPluginAdjustments(p.name(), "CreateContainer", rpl.Adjust, len(rpl.Update), len(rpl.Evict))
 	}
 
 	return rpl, nil
@@ -634,7 +646,10 @@ func (p *plugin) updateContainer(ctx context.Context, req *UpdateContainerReques
 	ctx, cancel := context.WithTimeout(ctx, getPluginRequestTimeout())
 	defer cancel()
 
+	start := time.Now()
 	rpl, err := p.impl.UpdateContainer(ctx, req)
+	p.r.metrics.RecordPluginLatency(p.name(), "UpdateContainer", time.Since(start))
+	p.r.metrics.RecordPluginInvocation(p.name(), "UpdateContainer", err)
 	if err != nil {
 		if isFatalError(err) {
 			log.Errorf(ctx, "closing plugin %s, failed to handle UpdateContainer request: %v",
@@ -643,6 +658,9 @@ func (p *plugin) updateContainer(ctx context.Context, req *UpdateContainerReques
 			return nil, nil
 		}
 		return nil, err
+	}
+	if rpl != nil {
+		p.r.metrics.RecordPluginAdjustments(p.name(), "UpdateContainer", nil, len(rpl.Update), len(rpl.Evict))
 	}
 
 	return rpl, nil
@@ -657,7 +675,10 @@ func (p *plugin) stopContainer(ctx context.Context, req *StopContainerRequest) (
 	ctx, cancel := context.WithTimeout(ctx, getPluginRequestTimeout())
 	defer cancel()
 
+	start := time.Now()
 	rpl, err = p.impl.StopContainer(ctx, req)
+	p.r.metrics.RecordPluginLatency(p.name(), "StopContainer", time.Since(start))
+	p.r.metrics.RecordPluginInvocation(p.name(), "StopContainer", err)
 	if err != nil {
 		if isFatalError(err) {
 			log.Errorf(ctx, "closing plugin %s, failed to handle StopContainer request: %v",
@@ -666,6 +687,9 @@ func (p *plugin) stopContainer(ctx context.Context, req *StopContainerRequest) (
 			return nil, nil
 		}
 		return nil, err
+	}
+	if rpl != nil {
+		p.r.metrics.RecordPluginAdjustments(p.name(), "StopContainer", nil, len(rpl.Update), 0)
 	}
 
 	return rpl, nil
@@ -679,7 +703,11 @@ func (p *plugin) updatePodSandbox(ctx context.Context, req *UpdatePodSandboxRequ
 	ctx, cancel := context.WithTimeout(ctx, getPluginRequestTimeout())
 	defer cancel()
 
-	if _, err := p.impl.UpdatePodSandbox(ctx, req); err != nil {
+	start := time.Now()
+	_, err := p.impl.UpdatePodSandbox(ctx, req)
+	p.r.metrics.RecordPluginLatency(p.name(), "UpdatePodSandbox", time.Since(start))
+	p.r.metrics.RecordPluginInvocation(p.name(), "UpdatePodSandbox", err)
+	if err != nil {
 		if isFatalError(err) {
 			log.Errorf(ctx, "closing plugin %s, failed to handle event %d: %v",
 				p.name(), Event_UPDATE_POD_SANDBOX, err)
@@ -701,7 +729,16 @@ func (p *plugin) StateChange(ctx context.Context, evt *StateChangeEvent) (err er
 	ctx, cancel := context.WithTimeout(ctx, getPluginRequestTimeout())
 	defer cancel()
 
-	if err = p.impl.StateChange(ctx, evt); err != nil {
+	start := time.Now()
+	err = p.impl.StateChange(ctx, evt)
+
+	var mask api.EventMask
+	mask.Set(evt.Event)
+	operation := fmt.Sprintf("StateChange/%s", mask.PrettyString())
+	p.r.metrics.RecordPluginLatency(p.name(), operation, time.Since(start))
+	p.r.metrics.RecordPluginInvocation(p.name(), operation, err)
+
+	if err != nil {
 		if isFatalError(err) {
 			log.Errorf(ctx, "closing plugin %s, failed to handle event %d: %v",
 				p.name(), evt.Event, err)
@@ -722,7 +759,10 @@ func (p *plugin) ValidateContainerAdjustment(ctx context.Context, req *ValidateC
 	ctx, cancel := context.WithTimeout(ctx, getPluginRequestTimeout())
 	defer cancel()
 
+	start := time.Now()
 	rpl, err := p.impl.ValidateContainerAdjustment(ctx, req)
+	p.r.metrics.RecordPluginLatency(p.name(), "ValidateContainerAdjustment", time.Since(start))
+	p.r.metrics.RecordPluginInvocation(p.name(), "ValidateContainerAdjustment", err)
 	if err != nil {
 		if isFatalError(err) {
 			log.Errorf(ctx, "closing plugin %s, failed to validate request: %v", p.name(), err)


### PR DESCRIPTION
Provides necessary hooks for container runtimes to collect basic runtime metrics regarding NRI plugin activity. This improves observability and helps satisfy v1.0 requirements.

Introduces a `Metrics` interface that allows us to collect plugin counts, invocations, adjustments, and latency information.

To avoid burying state change events under a generic operation name, `StateChange` invocations append the specific event type using human-readable strings (e.g., "StateChange/CreateContainer").

These hooks are called during plugin invocations and container lifecycle events. Runtimes can provide their own implementation of the `Metrics` interface (e.g. via a `WithMetrics` option) to route these data points into their existing telemetry setups.

Ref: https://github.com/containerd/nri/issues/272
Signed-off-by: Chris Henzie <chrishenzie@gmail.com>
Assisted-by: gemini-cli

```release-note
Add basic metrics collection for the NRI framework
```
