### PR TITLE
Add a background to lifecycle SVGs so they are legible in dark mode

### DIFF
--- a/docs/nri-container-lifecycle.svg
+++ b/docs/nri-container-lifecycle.svg
@@ -37,6 +37,8 @@
      inkscape:current-layer="svg480" />
   <title
      id="title2">Docs</title>
+  <!-- This rectangle acts as the background -->
+  <rect width="100%" height="100%" fill="#5b839b" />
   <g
      id="g6"
      transform="translate(-151.13236,-44.594905)">

--- a/docs/nri-pod-lifecycle.svg
+++ b/docs/nri-pod-lifecycle.svg
@@ -37,6 +37,8 @@
      inkscape:current-layer="svg304" />
   <title
      id="title2">Docs</title>
+  <!-- This rectangle acts as the background -->
+  <rect width="100%" height="100%" fill="#5b839b" />
   <g
      id="g6"
      transform="translate(-151.13236,-44.594905)">


### PR DESCRIPTION
I went with a blueprint color that is hopefully acceptable on both light and dark. 
Currently these images are illegible in README.md when viewing GitHub in dark mode.

We have to set the background within the SVG due to GitHub markdown stripping out CSS and other inline theming.