### PR TITLE
Fix .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 build/
 pkg/version/info/*
+!pkg/version/info/none


### PR DESCRIPTION
The existing `.gitignore` excluded `pkg/version/info`, but there was a force-added `pkg/version/info/none`. That file is required to build, but the `.gitignore` takes precedence when the repo is copied into another location (such as through `go mod vendor`). This commit series deletes and recreates the file, along with fixing the `.gitignore` rules.