### PR TITLE
Implementation of WithPluginRegistrationTimeout option

### DIFF
--- a/pkg/stub/stub.go
+++ b/pkg/stub/stub.go
@@ -283,6 +283,15 @@ func WithLogger(logger nrilog.Logger) Option {
 	}
 }
 
+// WithPluginRegistrationTimeout overrides the plugin's registration timeout
+// (default DefaultRegistrationTimeout, 5s).
+func WithPluginRegistrationTimeout(d time.Duration) Option {
+	return func(s *stub) error {
+		s.registrationTimeout = d
+		return nil
+	}
+}
+
 // stub implements Stub.
 type stub struct {
 	sync.Mutex

--- a/pkg/stub/stub_test.go
+++ b/pkg/stub/stub_test.go
@@ -1,0 +1,54 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package stub_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/containerd/nri/pkg/api"
+	"github.com/containerd/nri/pkg/stub"
+	"github.com/stretchr/testify/require"
+)
+
+type testPlugin struct{}
+
+func (testPlugin) RunPodSandbox(context.Context, *api.PodSandbox) error {
+	return nil
+}
+
+func TestWithPluginRegistrationTimeout(t *testing.T) {
+	const want = 7 * time.Second
+
+	s, err := stub.New(testPlugin{},
+		stub.WithPluginName("test"),
+		stub.WithPluginIdx("00"),
+		stub.WithPluginRegistrationTimeout(want),
+	)
+	require.NoError(t, err)
+	require.Equal(t, want, s.RegistrationTimeout())
+}
+
+func TestDefaultRegistrationTimeout(t *testing.T) {
+	s, err := stub.New(testPlugin{},
+		stub.WithPluginName("test"),
+		stub.WithPluginIdx("00"),
+	)
+	require.NoError(t, err)
+	require.Equal(t, stub.DefaultRegistrationTimeout, s.RegistrationTimeout())
+}


### PR DESCRIPTION
On a busy Kubernetes node, NRI plugin startup races against the runtime and loses. The plugin-side `DefaultRegistrationTimeout` is hardcoded at 5s with no override, while the runtime-side `plugin_registration_timeout` is operator-configurable (we set it to 10s in Uber env). 

When the plugin's 5s timer fires first. It gives up and closes its end of the ttrpc connection. Then the runtime finally accepts the connection. It reads the buffered register frame, which succeeds against stale state. The next call, Configure, returns `ttrpc.ErrClosed` right away because the plugin's side is already gone. The user sees `failed to register with NRI/Runtime: ttrpc: closed`. That hides the real cause: registration timed out before the runtime got to it.

The error made a lot of confusion for me. And in this PR I mirror the internal patch we did.