### PR TITLE
ci: declare contents: read on ci.yml and codespell.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
 
   checks:

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   codespell:
     name: Check for spelling errors


### PR DESCRIPTION
Two workflows currently inherit the default `GITHUB_TOKEN` scope:

- `ci.yml` (jobs: `checks`, `test-build`, `linters`, `tests`) — checkout + Go build/test.
- `codespell.yml` (job: `codespell`) — checkout + codespell-project/actions-codespell scan.

Neither pushes commits, opens issues, or calls write APIs. `contents: read` at the workflow level is the right minimum. `codeql.yml` in this repo already follows the same workflow-level pattern; this brings the remaining two CI workflows in line.