### PR TITLE
fix(adaptation): record sysctl removal markers in Linux.Sysctl

### DIFF
--- a/pkg/adaptation/result.go
+++ b/pkg/adaptation/result.go
@@ -504,7 +504,7 @@ func (r *result) adjustSysctl(sysctl map[string]string, plugin string) error {
 	}
 
 	for k := range del {
-		r.reply.adjust.Annotations[MarkForRemoval(k)] = ""
+		r.reply.adjust.Linux.Sysctl[MarkForRemoval(k)] = ""
 	}
 
 	return nil


### PR DESCRIPTION
#### What this PR does

`adjustSysctl` records sysctl removal markers in the wrong map. In its final loop over pure removals it writes to `Annotations`:

```go
for k := range del {
    r.reply.adjust.Annotations[MarkForRemoval(k)] = ""
}
```

The set-and-remove branch earlier in the same function already writes the correct map (`r.reply.adjust.Linux.Sysctl[MarkForRemoval(k)] = ""`), and `adjustAnnotations` is the function that legitimately writes `Annotations`. As written, a plugin's pure sysctl removal is not propagated to the container spec (`generate.AdjustSysctl` never sees the marker) and a spurious annotation-removal marker is emitted instead. This changes the final loop to write `Linux.Sysctl`.

#### On testing

I did not add a dedicated test here. Unlike annotations and mounts, sysctl removal is not exposed through a plugin-facing adjustment method (there is `SetLinuxSysctl` but no `RemoveLinuxSysctl`), so the removal-collection path is not exercised by the existing plugin-facing suite in `adaptation_suite_test.go`. The existing suite still passes (`go test ./pkg/adaptation/`). I am happy to follow up with a `RemoveLinuxSysctl` helper plus a removal test, or a focused test against `adjustSysctl`, whichever you prefer.

#### Notes

Verified with `go build`, `go vet`, `gofmt`, and the existing `./pkg/adaptation/` tests.
