### PR TITLE
adaptation: avoid holding lock across runtime update callback

### DIFF
--- a/pkg/adaptation/adaptation.go
+++ b/pkg/adaptation/adaptation.go
@@ -479,9 +479,6 @@ func (r *Adaptation) RemoveContainer(ctx context.Context, req *RemoveContainerRe
 
 // Perform a set of unsolicited container updates requested by a plugin.
 func (r *Adaptation) updateContainers(ctx context.Context, req []*ContainerUpdate) ([]*ContainerUpdate, error) {
-	r.Lock()
-	defer r.Unlock()
-
 	return r.updateFn(ctx, req)
 }
 


### PR DESCRIPTION
fix https://github.com/containerd/containerd/issues/13733

```release-note
Avoid containerd deadlock when an NRI plugin calls UpdateContainers during concurrent container updates
```
