### PR TITLE
ci: update actions, pin actions by sha, and apply zizmor fixes, and update to ubuntu 26.04

### DIFF
--- a/.github/actions/install-go/action.yml
+++ b/.github/actions/install-go/action.yml
@@ -3,7 +3,7 @@ description: "Reusable action to install Go, so there is one place to bump Go ve
 inputs:
   go-version:
     required: true
-    default: "1.24.3"
+    default: "1.24.x"
     description: "Go version to install"
 
 runs:

--- a/.github/actions/install-go/action.yml
+++ b/.github/actions/install-go/action.yml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
     - name: "Setup Go"
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v7.0.0
       with:
         go-version: ${{ inputs.go-version }}
         cache: false # see actions/setup-go#368

--- a/.github/actions/install-go/action.yml
+++ b/.github/actions/install-go/action.yml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
     - name: "Setup Go"
-      uses: actions/setup-go@v7.0.0
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version: ${{ inputs.go-version }}
         cache: false # see actions/setup-go#368

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
   checks:
     name: Project Checks
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 5
 
     steps:
@@ -42,7 +42,7 @@ jobs:
 
   test-build:
     name: Check buildability
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 5
 
     steps:
@@ -81,7 +81,7 @@ jobs:
     strategy:
       matrix:
         go-version: ["1.24.x"]
-        os: [ubuntu-22.04]
+        os: [ubuntu-26.04]
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -103,7 +103,7 @@ jobs:
 
   tests:
     name: Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 5
 
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
           echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.1
         with:
           path: src/github.com/containerd/nri
           fetch-depth: 25
@@ -41,7 +41,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.1
       - uses: $/.github/actions/install-go
 
       - name: Set env
@@ -76,7 +76,7 @@ jobs:
         os: [ubuntu-22.04]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.1
       - uses: $/.github/actions/install-go
         with:
           go-version: ${{ matrix.go-version }}
@@ -100,7 +100,7 @@ jobs:
         go-version: ["1.24.x"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.1
       - uses: $/.github/actions/install-go
         with:
           go-version: ${{ matrix.go-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,9 +86,9 @@ jobs:
         run: |
           echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
-      - uses: golangci/golangci-lint-action@v8
+      - uses: golangci/golangci-lint-action@v9.3.0
         with:
-          version: v2.4
+          version: v2.12
 
   tests:
     name: Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
           echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: src/github.com/containerd/nri
           fetch-depth: 25
@@ -36,7 +36,7 @@ jobs:
 
       - uses: $/.github/actions/install-go
 
-      - uses: containerd/project-checks@v1.2.2
+      - uses: containerd/project-checks@d7751f3c375b8fe4a84c02a068184ee4c1f59bc4 # v1.2.2
         with:
           working-directory: src/github.com/containerd/nri
 
@@ -46,7 +46,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -84,7 +84,7 @@ jobs:
         os: [ubuntu-22.04]
 
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -97,7 +97,7 @@ jobs:
         run: |
           echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
-      - uses: golangci/golangci-lint-action@v9.3.0
+      - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: v2.12
 
@@ -111,7 +111,7 @@ jobs:
         go-version: ["1.24.x"]
 
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           path: src/github.com/containerd/nri
           fetch-depth: 25
 
-      - uses: ./src/github.com/containerd/nri/.github/actions/install-go
+      - uses: $/.github/actions/install-go
 
       - uses: containerd/project-checks@v1.2.2
         with:
@@ -42,12 +42,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/install-go
-
-      # needed for wasm plugins
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
+      - uses: $/.github/actions/install-go
 
       - name: Set env
         shell: bash
@@ -82,7 +77,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/install-go
+      - uses: $/.github/actions/install-go
         with:
           go-version: ${{ matrix.go-version }}
 
@@ -106,7 +101,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/install-go
+      - uses: $/.github/actions/install-go
         with:
           go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   checks:
@@ -28,6 +32,7 @@ jobs:
         with:
           path: src/github.com/containerd/nri
           fetch-depth: 25
+          persist-credentials: false
 
       - uses: $/.github/actions/install-go
 
@@ -42,6 +47,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
+
       - uses: $/.github/actions/install-go
 
       - name: Set env
@@ -77,6 +85,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
+
       - uses: $/.github/actions/install-go
         with:
           go-version: ${{ matrix.go-version }}
@@ -101,6 +112,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
+
       - uses: $/.github/actions/install-go
         with:
           go-version: ${{ matrix.go-version }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,14 +2,16 @@ name: "CodeQL Scan"
 
 on:
   push:
-    branches:
-      - main
+    branches: [ main ]
   pull_request:
-    branches:
-      - main
+    branches: [ main ]
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   CodeQL-Build:
@@ -26,6 +28,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: $/.github/actions/install-go
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,14 +27,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - uses: $/.github/actions/install-go
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.37.7
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
 
       - name: Install protoc and plugins
         run: |
@@ -44,4 +44,4 @@ jobs:
       - run: make
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.37.7
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,9 +27,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
+      - uses: $/.github/actions/install-go
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.1
 
       - uses: $/.github/actions/install-go
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ jobs:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/analyze to upload SARIF results
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
 
     timeout-minutes: 30
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: $/.github/actions/install-go
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v4.37.7
 
       - name: Install protoc and plugins
         run: |
@@ -40,4 +40,4 @@ jobs:
       - run: make
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v4.37.7

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -16,6 +16,6 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.1
       - name: Codespell
         uses: codespell-project/actions-codespell@v2

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   codespell:
     name: Check for spelling errors
@@ -17,5 +21,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
       - name: Codespell
         uses: codespell-project/actions-codespell@v2.2

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -20,8 +20,8 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Codespell
-        uses: codespell-project/actions-codespell@v2.2
+        uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579 # v2.2

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7.0.1
       - name: Codespell
-        uses: codespell-project/actions-codespell@v2
+        uses: codespell-project/actions-codespell@v2.2

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -47,11 +47,11 @@ jobs:
           cosign-release: 'v2.5.3'
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4.2.0
 
       - name: Log in to registry
         if: github.event_name == 'push'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -81,7 +81,7 @@ jobs:
 
       - name: Build and push image
         id: build-and-push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7.3.0
         with:
           context: .
           file: ./plugins/Dockerfile

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -37,22 +37,22 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v4.1.2
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
           cosign-release: 'v2.5.3'
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.2.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to registry
         if: github.event_name == 'push'
-        uses: docker/login-action@v4.6.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -82,7 +82,7 @@ jobs:
 
       - name: Build and push image
         id: build-and-push
-        uses: docker/build-push-action@v7.3.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: ./plugins/Dockerfile

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -2,18 +2,17 @@ name: Publish Container Images
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
-permissions:
-  contents: read
 
 jobs:
   build-and-push:
@@ -39,6 +38,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install cosign
         if: github.event_name != 'pull_request'
@@ -60,13 +61,13 @@ jobs:
       - name: Determine image tag name
         id: tag
         run: |
-          if [ "${{ github.ref_type }}" = "tag" ]; then
-              tag="${{ github.ref_name }}"
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+              tag="${GITHUB_REF_NAME}"
           else
               if [ "${{ github.event_name }}" = "pull_request" ]; then
                   tag="pr-${{ github.event.pull_request.number }}"
               else
-                  case "${{ github.ref_name }}" in
+                  case "${GITHUB_REF_NAME}" in
                       main)
                           tag="unstable"
                           ;;

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@v4.1.2
         with:
           cosign-release: 'v2.5.3'
 

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.1
 
       - name: Install cosign
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
Update actions to avoid depending on deprecated node versions, set default permissions, and pin actions;

After this;

```bash
zizmor --fix=all --min-severity medium .
 INFO zizmor: 🌈 zizmor v1.29.0
 INFO audit: zizmor: 🌈 completed ./.github/actions/install-go/action.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/ci.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/codeql.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/codespell.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/images.yml
No findings to report. Good job! (1 ignored, 11 suppressed)
No fixes available to apply.
```
