### PR TITLE
docs: add context to nri image keys

### DIFF
--- a/pkg/api/api.pb.go
+++ b/pkg/api/api.pb.go
@@ -3242,9 +3242,15 @@ type Image struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Name         string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`                                     // image reference, e.g. "registry.k8s.io/pause:3.10"
-	Digest       string `protobuf:"bytes,2,opt,name=digest,proto3" json:"digest,omitempty"`                                 // resolved image index or manifest digest, e.g. "sha256:..."
-	ConfigDigest string `protobuf:"bytes,3,opt,name=config_digest,json=configDigest,proto3" json:"config_digest,omitempty"` // image config digest (platform-specific), e.g. "sha256:..."
+	// image reference, e.g. "registry.k8s.io/pause:3.10"
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// image index digest or manifest digest, e.g. "sha256:..."
+	// index media types: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json
+	// manifest media types: application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json
+	Digest string `protobuf:"bytes,2,opt,name=digest,proto3" json:"digest,omitempty"`
+	// image config digest (platform-specific), e.g. "sha256:..."
+	// config media types: application/vnd.oci.image.config.v1+json, application/vnd.docker.container.image.v1+json
+	ConfigDigest string `protobuf:"bytes,3,opt,name=config_digest,json=configDigest,proto3" json:"config_digest,omitempty"`
 }
 
 func (x *Image) Reset() {

--- a/pkg/api/api.proto
+++ b/pkg/api/api.proto
@@ -440,9 +440,15 @@ message Container {
 
 // Image identifies the container's image.
 message Image {
-  string name = 1;          // image reference, e.g. "registry.k8s.io/pause:3.10"
-  string digest = 2;        // resolved image index or manifest digest, e.g. "sha256:..."
-  string config_digest = 3; // image config digest (platform-specific), e.g. "sha256:..."
+  // image reference, e.g. "registry.k8s.io/pause:3.10"
+  string name = 1;
+  // image index digest or manifest digest, e.g. "sha256:..."
+  // index media types: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json
+  // manifest media types: application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json
+  string digest = 2;
+  // image config digest (platform-specific), e.g. "sha256:..."
+  // config media types: application/vnd.oci.image.config.v1+json, application/vnd.docker.container.image.v1+json
+  string config_digest = 3;
 }
 
 // Possible container states.


### PR DESCRIPTION
Following up on @mikebrow's [comment](https://github.com/containerd/nri/pull/302#issuecomment-5303453540) in #302 by adding more description to the parameters in the image structure. Also including an example implementation for containerd in https://github.com/containerd/containerd/pull/13960.