### PR TITLE
update plugins to current NRI version

### DIFF
--- a/plugins/device-injector/go.mod
+++ b/plugins/device-injector/go.mod
@@ -3,7 +3,7 @@ module github.com/containerd/nri/plugins/device-injector
 go 1.24.0
 
 require (
-	github.com/containerd/nri v0.6.1
+	github.com/containerd/nri v0.12.2
 	github.com/sirupsen/logrus v1.9.4
 	github.com/stretchr/testify v1.12.1
 	sigs.k8s.io/yaml v1.5.0

--- a/plugins/differ/go.mod
+++ b/plugins/differ/go.mod
@@ -3,7 +3,7 @@ module github.com/containerd/nri/plugins/differ
 go 1.24.0
 
 require (
-	github.com/containerd/nri v0.6.1
+	github.com/containerd/nri v0.12.2
 	github.com/r3labs/diff/v3 v3.0.2
 	github.com/sirupsen/logrus v1.9.4
 	github.com/sters/yaml-diff v0.4.0

--- a/plugins/hook-injector/go.mod
+++ b/plugins/hook-injector/go.mod
@@ -3,7 +3,7 @@ module github.com/containerd/nri/plugins/hook-injector
 go 1.24.2
 
 require (
-	github.com/containerd/nri v0.6.1
+	github.com/containerd/nri v0.12.2
 	github.com/opencontainers/runtime-spec v1.3.0
 	github.com/sirupsen/logrus v1.9.4
 	github.com/stretchr/testify v1.12.1

--- a/plugins/logger/go.mod
+++ b/plugins/logger/go.mod
@@ -3,7 +3,7 @@ module github.com/containerd/nri/plugins/logger
 go 1.24.0
 
 require (
-	github.com/containerd/nri v0.6.1
+	github.com/containerd/nri v0.12.2
 	github.com/sirupsen/logrus v1.9.4
 	sigs.k8s.io/yaml v1.5.0
 )

--- a/plugins/network-device-injector/go.mod
+++ b/plugins/network-device-injector/go.mod
@@ -3,7 +3,7 @@ module github.com/containerd/nri/plugins/network-device-injector
 go 1.24.0
 
 require (
-	github.com/containerd/nri v0.6.1
+	github.com/containerd/nri v0.12.2
 	github.com/containernetworking/plugins v1.4.1
 	github.com/sirupsen/logrus v1.9.4
 	github.com/vishvananda/netlink v1.2.1-beta.2

--- a/plugins/network-logger/go.mod
+++ b/plugins/network-logger/go.mod
@@ -3,7 +3,7 @@ module github.com/containerd/nri/plugins/network-logger
 go 1.24.0
 
 require (
-	github.com/containerd/nri v0.6.1
+	github.com/containerd/nri v0.12.2
 	github.com/sirupsen/logrus v1.9.4
 )
 

--- a/plugins/rdt/go.mod
+++ b/plugins/rdt/go.mod
@@ -6,7 +6,7 @@ replace github.com/containerd/nri => ../..
 
 require (
 	github.com/containerd/log v0.1.0
-	github.com/containerd/nri v0.0.0
+	github.com/containerd/nri v0.12.2
 	github.com/sirupsen/logrus v1.9.4
 	github.com/stretchr/testify v1.12.1
 )

--- a/plugins/template/go.mod
+++ b/plugins/template/go.mod
@@ -3,7 +3,7 @@ module github.com/containerd/nri/plugins/template
 go 1.24.0
 
 require (
-	github.com/containerd/nri v0.6.1
+	github.com/containerd/nri v0.12.2
 	github.com/sirupsen/logrus v1.9.4
 	sigs.k8s.io/yaml v1.5.0
 )

--- a/plugins/ulimit-adjuster/go.mod
+++ b/plugins/ulimit-adjuster/go.mod
@@ -6,7 +6,7 @@ replace github.com/containerd/nri => ../..
 
 require (
 	github.com/containerd/log v0.1.0
-	github.com/containerd/nri v0.6.1
+	github.com/containerd/nri v0.12.2
 	github.com/sirupsen/logrus v1.9.4
 	github.com/stretchr/testify v1.12.1
 	sigs.k8s.io/yaml v1.5.0

--- a/plugins/wasm/go.mod
+++ b/plugins/wasm/go.mod
@@ -2,7 +2,7 @@ module github.com/containerd/nri/plugins/wasm
 
 go 1.24.0
 
-require github.com/containerd/nri v0.6.1
+require github.com/containerd/nri v0.12.2
 
 require (
 	github.com/containerd/log v0.1.0 // indirect

--- a/plugins/writable-cgroups/go.mod
+++ b/plugins/writable-cgroups/go.mod
@@ -3,7 +3,7 @@ module github.com/containerd/nri/plugins/writable-cgroups
 go 1.24.0
 
 require (
-	github.com/containerd/nri v0.6.1
+	github.com/containerd/nri v0.12.2
 	github.com/moby/sys/mountinfo v0.7.2
 	github.com/sirupsen/logrus v1.9.4
 	github.com/stretchr/testify v1.12.1


### PR DESCRIPTION
- relates to https://github.com/containerd/nri/pull/313#discussion_r3825787517


They are tested with the "replace" rule in place, which corresponds with current main. Update them to the current release, which is a closer match than the v0.6.x versions.